### PR TITLE
Add IXO USSD gateway documentation and normalize developer nav

### DIFF
--- a/api-reference/index.mdx
+++ b/api-reference/index.mdx
@@ -24,6 +24,9 @@ This section documents API interfaces only. It does not define protocol concepts
   <Card title="Registry API" href="/api-reference/registry-api" icon="database">
     Application API for Impact Hub Registry service workflows.
   </Card>
+  <Card title="USSD gateway API" href="/api-reference/ussd-api" icon="tower-cell">
+    Session endpoint for the IXO USSD gateway — accepts input from telecom gateways and returns USSD responses.
+  </Card>
 </CardGroup>
 
 ## Boundary between protocol and services

--- a/api-reference/ussd-api.mdx
+++ b/api-reference/ussd-api.mdx
@@ -1,0 +1,201 @@
+---
+title: "USSD gateway API"
+icon: "tower-cell"
+description: "Endpoint reference for the IXO USSD gateway session API."
+---
+
+## Overview
+
+The IXO USSD gateway exposes a single session endpoint that telecom gateways call for each user interaction, plus debug and health endpoints for operators.
+
+All endpoints accept and return JSON unless otherwise noted. The main session endpoint returns plain text in the USSD response format.
+
+## Authentication
+
+The `/api/ussd` endpoint does not require authentication by default. It is intended to be called by your telecom gateway server, not directly from a browser. Restrict access at the network or reverse-proxy layer in production.
+
+## Base URL
+
+```text
+http://YOUR_SERVER:3000
+```
+
+The default port is `3000`. Set `PORT` in your environment to override.
+
+## Session endpoint
+
+### POST /api/ussd
+
+Processes a USSD interaction. Called by the telecom gateway once per user input during a session.
+
+**Request**
+
+```json
+{
+  "sessionId": "string",
+  "serviceCode": "string",
+  "phoneNumber": "string",
+  "text": "string"
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `sessionId` | string | yes | Unique session identifier assigned by the telecom gateway |
+| `serviceCode` | string | yes | USSD service code the user dialled, e.g. `*1234#` |
+| `phoneNumber` | string | yes | User's phone number in E.164 international format, e.g. `+260971234567` |
+| `text` | string | yes | User input accumulated during the session. Empty string on initial dial |
+
+**Validation rules**
+
+- `phoneNumber` must be E.164 format
+- `serviceCode` must match USSD format, e.g. `*1234#` or `*123*456#`
+- `text` maximum 182 characters (USSD protocol limit)
+- `sessionId` maximum 100 characters
+
+**Response**
+
+Plain text. The first word indicates whether the session continues or ends.
+
+```
+CON <menu text>
+```
+```
+END <closing message>
+```
+
+| Prefix | Meaning |
+|---|---|
+| `CON` | Session continues — display the menu and wait for the next input |
+| `END` | Session closed — display the message and end the USSD session |
+
+**Example — initial dial**
+
+```bash
+curl -X POST http://localhost:3000/api/ussd \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "session-001",
+    "serviceCode": "*1234#",
+    "phoneNumber": "+260971234567",
+    "text": ""
+  }'
+```
+
+Response:
+
+```
+CON Welcome to IXO USSD
+1. Know More
+2. Account Menu
+*. Exit
+```
+
+**Example — user selects option 1**
+
+```bash
+curl -X POST http://localhost:3000/api/ussd \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "session-001",
+    "serviceCode": "*1234#",
+    "phoneNumber": "+260971234567",
+    "text": "1"
+  }'
+```
+
+Response:
+
+```
+CON Information Center
+1. About this service
+2. Pricing
+3. Delivery
+*. Exit
+```
+
+## Debug endpoints
+
+### GET /api/ussd/debug/:sessionId
+
+Returns the current state and context for an active session. Intended for operator debugging only — do not expose publicly.
+
+**Response**
+
+```json
+{
+  "sessionId": "session-001",
+  "debugInfo": {
+    "state": "preMenu",
+    "context": {
+      "sessionId": "session-001",
+      "phoneNumber": "+260971234567",
+      "message": "Welcome to IXO USSD...",
+      "isAuthenticated": false
+    },
+    "status": "active"
+  },
+  "activeSessions": ["session-001"]
+}
+```
+
+### GET /api/ussd/sessions
+
+Returns all currently active session IDs.
+
+```json
+{
+  "activeSessions": ["session-001", "session-002"],
+  "count": 2
+}
+```
+
+## Health endpoints
+
+### GET /health
+
+Returns application health with database connectivity status.
+
+```json
+{
+  "status": "ok",
+  "environment": "production",
+  "timestamp": "2026-04-22T10:00:00.000Z",
+  "uptime": 3600,
+  "database": "connected"
+}
+```
+
+### GET /
+
+Basic health check for platform-as-a-service health probes.
+
+```json
+{
+  "status": "ok",
+  "message": "ixo-ussd-server running",
+  "environment": "production",
+  "timestamp": "2026-04-22T10:00:00.000Z"
+}
+```
+
+## Errors
+
+| Response | Cause | What to do |
+|---|---|---|
+| `END Invalid input. Please try again.` | Request failed validation | Check phone number is E.164, service code format, and text length |
+| `END Service temporarily unavailable. Please try again later.` | Server or database error | Check `/health` for database connectivity |
+| Session not found on `GET /debug/:sessionId` | Session expired or never started | Sessions expire after inactivity; the user must dial again |
+
+**Rate limiting:** 100 requests per minute per IP address. Requests exceeding this return HTTP 429.
+
+## Security notes
+
+- User PINs are encrypted at rest with AES-256 using the `PIN_ENCRYPTION_KEY` environment variable.
+- All inputs are validated and sanitised before processing.
+- Set `TRUST_PROXY_ENABLED=true` when running behind a reverse proxy so rate limiting uses the real client IP.
+
+## Related guides
+
+- [Deploy the IXO USSD gateway](/guides/dev/ussd-gateway) — setup, environment configuration, and telecom gateway integration
+- [IXO USSD gateway overview](/articles/ixo-ussd) — architecture and integration model

--- a/articles/intro-platforms.mdx
+++ b/articles/intro-platforms.mdx
@@ -24,6 +24,9 @@ This page describes the IXO Platform architecture model. Use guides and referenc
   <Card title="AI Agents" icon="sparkles">
     Intelligent interface agents and automation
   </Card>
+  <Card title="USSD" icon="tower-cell" href="/articles/ixo-ussd">
+    Offline access to IXO services from any GSM phone — no smartphone or data plan required
+  </Card>
 </CardGroup>
 
 ### 2. Applications

--- a/articles/ixo-ussd.mdx
+++ b/articles/ixo-ussd.mdx
@@ -1,0 +1,90 @@
+---
+title: "IXO USSD gateway"
+icon: "tower-cell"
+description: "How the IXO USSD gateway extends IXO services to any GSM mobile phone."
+---
+
+<Tip>
+The IXO USSD gateway is an open-source tool that makes IXO Protocol services accessible from any GSM phone — no smartphone, app, or data plan required. This page explains its architecture and role in the IXO ecosystem. For setup instructions, see the [developer guide](/guides/dev/ussd-gateway).
+</Tip>
+
+## Role in the IXO ecosystem
+
+USSD (Unstructured Supplementary Service Data) is a real-time text session protocol built into every GSM network. A user dials a short code such as `*1234#`, navigates menus via number keys, and receives responses — all within a live network session.
+
+The IXO USSD gateway sits between a telecom network and IXO services. It receives USSD sessions from a telecom gateway, processes user input through configurable state machine flows, and calls IXO Protocol and IXO Matrix services to create identities, issue credentials, and record verifiable impact data.
+
+<AccordionGroup>
+  <Accordion title="How a session works" icon="route">
+    1. A user dials the USSD service code on any GSM phone.
+    2. The telecom gateway (such as Africa's Talking) forwards the session to the IXO USSD gateway as an HTTP POST request.
+    3. The gateway processes the input through an XState v5 state machine and returns a `CON` (continue) or `END` (close) response.
+    4. The user navigates menus until the session completes or times out.
+    5. Completed actions — account creation, credential issuance, impact reporting — are recorded on the IXO Protocol and stored in an IXO Matrix data vault.
+  </Accordion>
+  <Accordion title="Integration with IXO services" icon="plug">
+    The gateway integrates with:
+
+    - **IXO Protocol** — creates Decentralized Identifiers (DIDs) and blockchain wallets for new users, and writes verifiable claims on behalf of the user
+    - **IXO Matrix** — stores encrypted user data and private keys in a Matrix-based data vault
+    - **PostgreSQL** — maintains session state across USSD interactions for each user
+  </Accordion>
+  <Accordion title="Open-source and forkable" icon="code-fork">
+    The gateway is designed to be forked and adapted. The core framework — state machines, session management, database layer, and IXO service integrations — is reusable across any impact use case. Operators fork the repository, define their own USSD flows as state machines, and deploy against their own telecom gateway and IXO network.
+  </Accordion>
+</AccordionGroup>
+
+## Concept model
+
+<CardGroup>
+  <Card title="State machines" icon="diagram-project">
+    Each USSD flow is an XState v5 state machine. Parent machines orchestrate flows; child machines handle specific screens and business logic.
+  </Card>
+  <Card title="Session management" icon="clock-rotate-left">
+    PostgreSQL stores active session state. Each USSD session maps to a state machine instance keyed by session ID and phone number.
+  </Card>
+  <Card title="Telecom gateway bridge" icon="tower-broadcast">
+    Any telecom gateway that sends HTTP POST requests with session ID, service code, phone number, and text input is compatible. Africa's Talking is the reference integration.
+  </Card>
+  <Card title="IXO identity and credentials" icon="id-card">
+    On account creation, the gateway generates a DID and blockchain wallet for the user, and stores encrypted credentials in an IXO Matrix data vault.
+  </Card>
+</CardGroup>
+
+## Typical use cases
+
+<CardGroup>
+  <Card title="Offline user onboarding" icon="user-plus">
+    Register community members on IXO without a smartphone — collect name, set a PIN, create a DID and wallet.
+  </Card>
+  <Card title="Impact activity reporting" icon="file-circle-check">
+    Let field workers or household members report verified activities (such as clean cooking sessions) via USSD, triggering credential issuance on-chain.
+  </Card>
+  <Card title="Digital voucher management" icon="ticket">
+    Issue and redeem digital vouchers for goods or services through USSD menus, with on-chain settlement.
+  </Card>
+  <Card title="Low-connectivity data collection" icon="signal">
+    Collect structured data from areas with no mobile data coverage using only voice-quality GSM connectivity.
+  </Card>
+</CardGroup>
+
+## Reference implementation
+
+Emerging Household Energy (Supamoto) uses the IXO USSD gateway as the offline access channel for rural household members in Zambia. The Supamoto deployment is maintained as an open-source fork at [emerging-eco/ixo-ussd-supamoto](https://github.com/emerging-eco/ixo-ussd-supamoto). See [USSD access channel](/platforms/Emerging/ussd-channel) for details.
+
+## Go here next
+
+<CardGroup>
+  <Card title="Deploy the IXO USSD gateway" icon="server" href="/guides/dev/ussd-gateway">
+    Fork, configure, and run the gateway for your use case.
+  </Card>
+  <Card title="USSD gateway API" icon="code" href="/api-reference/ussd-api">
+    Endpoint reference for the USSD session API.
+  </Card>
+  <Card title="Use IXO via USSD" icon="mobile" href="/guides/users/ussd">
+    End-user guide for accessing IXO services on a basic phone.
+  </Card>
+  <Card title="Source repository" icon="github" href="https://github.com/ixoworld/ixo-ussd">
+    Fork the open-source IXO USSD gateway on GitHub.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -25,22 +25,29 @@
           {
             "group": "Developers",
             "pages": [
+              "guides/dev/overview",
               "guides/dev/spatial-web-sdks",
-              "guides/dev/domain-settings",
-              "guides/digital-twins",
-              "guides/domain-registration",
-              "guides/dev/domain-privacy",
+              "mcp/model-context-protocol",
+              {
+                "group": "Developer Guides",
+                "pages": [
+                  "guides/dev/ussd-gateway"
+                ]
+              },
               "guides/dev/authentication",
               "guides/dev/ixo-claims",
-              "guides/registry",
+              "guides/digital-twins",
+              "guides/domain-registration",
+              "guides/dev/domain-settings",
+              "guides/dev/domain-privacy",
               "guides/digital-mrv",
-              "guides/ixo-oracles-architecture",
-              "mcp/model-context-protocol"
+              "guides/registry",
+              "guides/ixo-oracles-architecture"
             ]
           },
           {
             "group": "User Guides",
-            "pages": ["guides/users/intro-users"]
+            "pages": ["guides/users/intro-users", "guides/users/ussd"]
           },
           {
             "group": "Platforms",
@@ -53,6 +60,7 @@
               "articles/cdt-systems",
               "articles/ixo-blockchain",
               "articles/ixo-matrix",
+              "articles/ixo-ussd",
               "articles/ixo-blocksync",
               "articles/ixo-oracles",
               "articles/pods",
@@ -79,6 +87,7 @@
                 "group": "Emerging",
                 "pages": [
                   "platforms/Emerging/intro-emerging",
+                  "platforms/Emerging/ussd-channel",
                   "platforms/Emerging/concepts",
                   "platforms/Emerging/digital-identifiers",
                   "platforms/Emerging/credential-issuance",
@@ -127,6 +136,10 @@
           {
             "group": " ",
             "pages": ["api-reference/registry-api"]
+          },
+          {
+            "group": " ",
+            "pages": ["api-reference/ussd-api"]
           },
           {
             "group": " ",

--- a/guides/dev/overview.mdx
+++ b/guides/dev/overview.mdx
@@ -1,208 +1,72 @@
 ---
-title: 'Developer Overview'
-description: 'Getting started with IXO development'
+title: 'Overview'
+icon: 'code'
+description: 'Find the right starting point for building on IXO.'
 ---
 
 <Tip>
-  This guide provides an overview of the IXO development ecosystem, including available SDKs, APIs, and resources to help you build applications on the Spatial Web Stack.
+IXO provides TypeScript SDKs, REST and RPC APIs, and deployable gateway tools for building on the IXO Protocol. This page points you to the right entry point based on what you want to do.
 </Tip>
 
-## Development Stack
+## Choose your starting point
 
 <CardGroup>
-  <Card title="IXO SDKs" icon="code" href="/sdk-reference/index">
-    Software Development Kits for building Spatial Web applications
+  <Card title="SDKs and tools" icon="toolbox" href="/guides/dev/spatial-web-sdks">
+    Browse TypeScript SDKs and deployable gateway tools, including the IXO MultiClient SDK, IXO Matrix Client SDK, and IXO USSD gateway
   </Card>
-  
-  <Card title="API Reference" icon="book" href="/api-reference/authentication">
-    Comprehensive API documentation
+  <Card title="API reference" icon="server" href="/api-reference">
+    REST, RPC, GraphQL, and service API interfaces for IXO Protocol and application services
   </Card>
-  
-  <Card title="Blockchain" icon="cube" href="/articles/ixo-protocol">
-    IXO Protocol blockchain for digital twins and impact claims
-  </Card>
-  
-  <Card title="IXO Matrix" icon="database" href="/articles/ixo-matrix">
-    Secure data storage and messaging
-  </Card>
-</CardGroup>
-
-## Core SDKs
-
-<AccordionGroup>
-  <Accordion title="IXO MultiClient SDK" icon="network-wired">
-    ```bash
-    npm install @ixo/impactxclient-sdk
-    ```
-    
-    The IXO MultiClient SDK provides a unified interface for interacting with:
-    - IXO Protocol blockchain
-    - IXO Matrix data storage
-    - Agentic Oracles
-    - Digital twin management
-    
-    [Learn more about the IXO MultiClient SDK](/sdk-reference/multiclient-sdk)
-  </Accordion>
-  
-  <Accordion title="IXO Matrix Client SDK" icon="database">
-    ```bash
-    npm install @ixo/matrixclient-sdk
-    ```
-    
-    The IXO Matrix Client SDK enables:
-    - Secure data room creation
-    - End-to-end encrypted messaging
-    - File storage
-    - Access control management
-    
-    [Learn more about the IXO Matrix Client SDK](/sdk-reference/matrix-client-sdk)
-  </Accordion>
-  
-  <Accordion title="Agentic Oracles SDK" icon="brain">
-    ```bash
-    npm install @ixo/oracle-agent-sdk
-    ```
-    
-    The Oracle Agent SDK allows you to build:
-    - Verification oracles
-    - Data validation services
-    - Intelligent automation agents
-    - Attestation services
-    
-    [Learn more about the Agentic Oracles SDK](/sdk-reference/oracle-ai-sdk)
-  </Accordion>
-</AccordionGroup>
-<Info>
-> If you are using the [IXO Spatial Web Multiclient SDK](IXO-Spatial-Web-Multiclient-SDK.md), familiarize yourself with the [Signing Client](https://www.npmjs.com/package/@ixo/impactxclient-sdk#signing-client) to understand how to sign and broadcast transactions.
-Familiarize yourself with the [IXO Blocksync GraphQL](Blocksync-GraphQL-API-Overview.md) queries for retrieving data from the blockchain.
-</Info>
-
-## Key Modules
-
-These modules provide specific functionality that can be used independently or in combination to build your application.
-
-<CardGroup>
-  <Card title="Digital Twins" icon="cube" href="/guides/dev/ixo-domains">
-    Create and manage digital representations of real-world entities
-  </Card>
-  
-  <Card title="Claims" icon="file-check" href="/guides/dev/ixo-claims">
-    Submit and verify impact claims with evidence
-  </Card>
-  
-  <Card title="Data Rooms" icon="vault" href="/articles/ixo-matrix">
-    Set up secure data storage with controlled access
-  </Card>
-  
   <Card title="Authentication" icon="key" href="/guides/dev/authentication">
-    Implement secure authentication and authorization
+    Set up credentials, session keys, and authorization to connect to IXO services
+  </Card>
+  <Card title="Networks and endpoints" icon="network-wired" href="/reference/networks-and-endpoints">
+    Mainnet and testnet connection details, chain IDs, and base URLs
   </Card>
 </CardGroup>
 
-## Getting Started
+## Build specific capabilities
 
-<Steps>
-  <Step title="Set Up Development Environment">
-    Install the necessary SDKs for your project:
-    
-    ```bash
-    # Install core SDKs
-    npm install @ixo/impactxclient-sdk @ixo/matrixclient-sdk
-    ```
-  </Step>
-  
-  <Step title="Configure Clients">
-    ```typescript
-    import { createClient } from "@ixo/impactxclient-sdk";
-    import { createMatrixClient } from "@ixo/matrixclient-sdk";
-    
-    // Initialize blockchain client
-    const chain = await createClient({
-      rpcEndpoint: "https://rpc.ixo.world",
-      chainId: "ixo-5"
-    });
-    
-    // Initialize Matrix client
-    const matrix = await createMatrixClient({
-      baseUrl: "https://matrix.ixo.world",
-      accessToken: "YOUR_ACCESS_TOKEN"
-    });
-    ```
-  </Step>
-  
-  <Step title="Implement Core Functionality">
-    Use the SDKs to implement your application's core features:
-    
-    ```typescript
-    // Create a digital twin entity
-    const entity = await chain.createEntity({
-      type: "Asset",
-      name: "Solar Panel Array",
-      data: {
-        capacity: "5kW",
-        location: "51.5074,-0.1278"
-      }
-    });
-    
-    // Create a secure data room
-    const room = await matrix.createRoom({
-      name: "Entity Data Room",
-      encryption: true
-    });
-    
-    // Store data securely
-    await matrix.sendEvent(room.roomId, "m.room.message", {
-      msgtype: "m.data",
-      body: JSON.stringify(sensorData)
-    });
-    ```
-  </Step>
-</Steps>
+<CardGroup>
+  <Card title="Digital twins" icon="cube" href="/guides/digital-twins">
+    Create and manage entity domains for real-world systems, assets, and organisations
+  </Card>
+  <Card title="Claims and verification" icon="file-check" href="/guides/dev/ixo-claims">
+    Submit and verify impact claims with evidence using IXO Protocol claims modules
+  </Card>
+  <Card title="Digital MRV" icon="chart-line" href="/guides/digital-mrv">
+    Set up digital measurement, reporting, and verification workflows
+  </Card>
+  <Card title="Agentic Oracles" icon="brain" href="/guides/ixo-oracles-architecture">
+    Build AI-powered oracle services for verification, evaluation, and automation
+  </Card>
+  <Card title="Domain settings" icon="sliders" href="/guides/dev/domain-settings">
+    Configure entity domain permissions, services, and linked resources
+  </Card>
+  <Card title="Model Context Protocol (MCP)" icon="plug" href="/mcp/model-context-protocol">
+    Connect AI tools to IXO services through MCP servers
+  </Card>
+</CardGroup>
 
-## Example Use Cases
-
-The IXO development stack can be used to build a wide range of applications. Here are some example use cases to help you understand how these modules can be used together for specific applications.
+## Core concepts
 
 <AccordionGroup>
-  <Accordion title="Digital MRV System" icon="chart-line">
-    A system for measuring, reporting, and verifying impact data:
-    
-    - **Digital Twins**: Create entities for projects and devices
-    - **Data Rooms**: Store sensor data securely
-    - **Claims**: Submit and verify impact claims
-    - **Oracles**: Validate data and generate attestations
-    
-    [View MRV Example](/guides/dev/examples)
+  <Accordion title="IXO Protocol" icon="cube">
+    The IXO Protocol is a Cosmos SDK blockchain for coordinating, financing, and verifying real-world impacts. Core modules cover entity management, claims, tokens, bonds, and smart accounts. [Read the protocol overview](/articles/ixo-protocol).
   </Accordion>
-  
-  <Accordion title="Secure Collaboration Platform" icon="users">
-    A platform for secure collaboration on sensitive data:
-    
-    - **Data Rooms**: Create encrypted spaces for collaboration
-    - **Authentication**: Manage user access and permissions
-    - **Messaging**: Enable secure communication
-    - **File Storage**: Share documents securely
-    
-    [View Collaboration Example](/guides/dev/examples)
+  <Accordion title="Domains and digital twins" icon="diagram-project">
+    Domains are on-chain representations of real-world entities — organisations, projects, assets, and devices. Each domain has a Decentralized Identifier (DID), controllers, services, and a linked IXO Matrix data room. [Learn about digital twins](/guides/digital-twins).
+  </Accordion>
+  <Accordion title="IXO Matrix" icon="database">
+    IXO Matrix is the encrypted data and communication layer. Applications use it for secure data rooms, evidence storage, and messaging linked to on-chain state. [Read the Matrix overview](/articles/ixo-matrix).
+  </Accordion>
+  <Accordion title="Agentic Oracles" icon="brain">
+    Agentic Oracles are AI-powered services that process impact claims, validate evidence, and write verifiable attestations to the IXO Protocol. [Learn about Agentic Oracles](/articles/ixo-oracles).
   </Accordion>
 </AccordionGroup>
 
-## Resources
+## Developer resources
 
-<CardGroup>
-  <Card title="API Reference" icon="book" href="/api-reference/authentication">
-    Detailed API documentation
-  </Card>
-  
-  <Card title="Examples" icon="lightbulb" href="/guides/dev/examples">
-    Implementation examples and tutorials
-  </Card>
-  
-  <Card title="GitHub" icon="github" href="https://github.com/ixofoundation">
-    Source code and examples
-  </Card>
-  
-  <Card title="Community" icon="users" href="https://ixofoundation.slack.com/archives/C04UERAUHQT">
-    Developer community and support
-  </Card>
-</CardGroup>
+- [IXO open-source repositories](https://github.com/ixofoundation) — source code for SDKs, gateway tools, and reference implementations
+- [Developer community](https://ixofoundation.slack.com/archives/C04UERAUHQT) — questions, discussions, and support
+- [Product and SDK map](/reference/product-and-sdk-map) — canonical list of products, SDKs, and their package identifiers

--- a/guides/dev/spatial-web-sdks.mdx
+++ b/guides/dev/spatial-web-sdks.mdx
@@ -1,162 +1,55 @@
 ---
-title: 'Spatial Web SDKs'
+title: 'IXO SDKs and tools'
 icon: 'code'
-description: 'Build advanced applications for the Spatial Web using the comprehensive suite of IXO development tools'
+description: 'Libraries and gateway tools for building on IXO'
 ---
 
 <Tip>
-The IXO Spatial Web SDKs provide developers with the tools to build real-world applications that leverage digital twins, Agentic Oracles, secure data rooms, and interchain networks.
+IXO provides TypeScript SDKs for integrating with the IXO Protocol, IXO Matrix, and related services, as well as deployable gateway tools for extending IXO access to offline and mobile channels.
 </Tip>
 
-## Available SDKs
+## SDKs
+
+Install these packages to integrate IXO services into your application.
 
 <CardGroup>
 
-<Card title="MultiClient SDK" icon="network-wired" href="/sdk-reference/multiclient-sdk">
-  Connect with IXO and Cosmos networks for interchain operations
+<Card title="IXO MultiClient SDK" icon="network-wired" href="/sdk-reference/multiclient-sdk">
+  Interact with IXO Protocol modules, Cosmos chains, and interchain services from TypeScript
 </Card>
 
-<Card title="Matrix Client SDK" icon="database" href="/sdk-reference/matrix-client-sdk">
-  Build secure data rooms and encrypted communication channels
+<Card title="IXO Matrix Client SDK" icon="database" href="/sdk-reference/matrix-client-sdk">
+  Create and manage encrypted data rooms and secure messaging on IXO Matrix
 </Card>
 
-<Card title="Oracles SDK" icon="brain" href="/sdk-reference/oracle-ai-sdk">
-  Create AI-powered autonomous agents
+<Card title="Personal Agent SDK" icon="brain" href="/sdk-reference/oracle-ai-sdk">
+  Build personal AI agents that interact with IXO services and verifiable data
+</Card>
+
+<Card title="IXO SignX SDK" icon="signature" href="/sdk-reference/signx-sdk">
+  Enable mobile-to-web signing and authentication using IXO SignX
 </Card>
 
 <Card title="JAMBO Wallet SDK" icon="wallet" href="/sdk-reference/jambo-wallet-sdk">
-  Manage digital assets and credentials in the JAMBO wallet
-</Card>
-
-<Card title="SignX SDK" icon="signature" href="/sdk-reference/signx-sdk">
-  Enable secure mobile-to-web authentication and transaction signing
+  Integrate digital asset and credential management into the JAMBO wallet
 </Card>
 
 </CardGroup>
 
-## Installation
+## Gateway tools
 
-```bash
-# Install core SDKs
-npm install @ixo/impactxclient-sdk @ixo/matrixclient-sdk
-npm install @ixo/assistant-sdk @ixo/jambo-wallet-sdk
-```
-
-## Basic Setup
-
-<CodeGroup>
-
-```typescript IXO MultiClient SDK
-import { createClient } from "@ixo/impactxclient-sdk";
-
-// Initialize client
-const chain = await createClient({
-  rpcEndpoint: RPC_ENDPOINT,
-  chainId: "ixo-5"
-});
-
-// Create digital twin
-const twin = await chain.entity.create({
-  type: "DigitalTwin",
-  controller: "did:ixo:org/123"
-});
-```
-
-```typescript Matrix Client
-import { createMatrixClient } from "@ixo/matrixclient-sdk";
-
-// Initialize Matrix client
-const matrix = await createMatrixClient({
-  baseUrl: MATRIX_ENDPOINT,
-  accessToken: USER_TOKEN
-});
-
-// Create secure data room
-const room = await matrix.createRoom({
-  name: "Secure Data Room",
-  encryption: true,
-  visibility: "private"
-});
-```
-
-```typescript Assistant
-import { createAssistant } from "@ixo/assistant-sdk";
-
-// Initialize assistant
-const assistant = await createAssistant({
-  type: "VerificationAgent",
-  capabilities: ["verification", "analytics"]
-});
-
-// Process verification request
-const result = await assistant.verify({
-  data: inputData,
-  context: verificationContext
-});
-```
-
-```typescript JAMBO Wallet
-import { createWallet } from "@ixo/jambo-wallet-sdk";
-
-// Initialize wallet
-const wallet = await createWallet({
-  storageType: "secure",
-  network: "mainnet"
-});
-
-// Manage credentials
-const credential = await wallet.createCredential({
-  type: "VerifiableCredential",
-  issuer: "did:ixo:issuer/123"
-});
-```
-
-</CodeGroup>
-
-## Key Features
-
-### MultiClient SDK
-- Interchain transactions and queries
-- Digital twin management
-- Entity state management
-- Blockchain service management
-
-### Matrix Client SDK
-- End-to-end encrypted data rooms
-- Secure messaging and file storage
-- Access control management
-- Real-time data streaming
-
-### Oracles SDK
-- AI-powered agent services
-- Analytics processing
-- Evidence collection
-- Proof generation
-
-### JAMBO Wallet SDK
-- Credential management
-- Digital asset operations
-- Secure key storage
-- Transaction signing
-
-## Next Steps
+Fork or deploy these tools to extend IXO services to additional channels and environments.
 
 <CardGroup>
 
-<Card title="API Reference" icon="code">
-  View detailed SDK documentation
-</Card>
-
-<Card title="Examples" icon="lightbulb">
-  Explore sample applications
-</Card>
-
-<Card title="GitHub" icon="github">
-  Access SDK source code
-</Card>
-
-<Card title="Support" icon="headset">
-  Get developer support
+<Card title="IXO USSD gateway" icon="tower-cell" href="/articles/ixo-ussd">
+  Give any GSM mobile phone access to IXO services — no smartphone or data plan required
 </Card>
 
 </CardGroup>
+
+## Next steps
+
+- [SDK reference](/sdk-reference) — full reference for each SDK
+- [API reference](/api-reference) — IXO service APIs
+- [Developer overview](/guides/dev/overview) — task guides for common developer workflows

--- a/guides/dev/ussd-gateway.mdx
+++ b/guides/dev/ussd-gateway.mdx
@@ -1,0 +1,175 @@
+---
+title: "Deploy the IXO USSD gateway"
+icon: "tower-cell"
+description: "Fork, configure, and run the open-source IXO USSD gateway to give any GSM phone access to IXO services."
+---
+
+## Before you start
+
+- Node.js 20 or later
+- pnpm (`npm install -g pnpm`)
+- PostgreSQL 14 or later
+- A telecom gateway account (such as [Africa's Talking](https://africastalking.com)) for live USSD testing
+- Docker — required only for integration tests
+
+## What this guide does
+
+This guide walks you through forking the IXO USSD gateway, configuring it for your environment, and running it against a telecom gateway. At the end you will have a working USSD server that can accept real or simulated sessions and write results to IXO Protocol.
+
+The gateway is designed to be forked. You define your own USSD flows as XState v5 state machines. The core session management, database layer, and IXO service integrations come pre-built.
+
+## Step 1 — Fork and clone the repository
+
+Fork [ixoworld/ixo-ussd](https://github.com/ixoworld/ixo-ussd) on GitHub, then clone your fork and install dependencies.
+
+```bash
+git clone https://github.com/YOUR_USERNAME/ixo-ussd.git
+cd ixo-ussd
+pnpm install
+```
+
+## Step 2 — Configure environment variables
+
+Copy the example environment file and edit it with your values.
+
+```bash
+cp env.example .env
+```
+
+### Required variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string | `postgres://user:pass@localhost:5432/ixo-ussd-dev` |
+| `PIN_ENCRYPTION_KEY` | 32-character key for PIN encryption | generate with `openssl rand -hex 16` |
+| `LOG_LEVEL` | Logging verbosity | `debug`, `info`, `warn`, `error` |
+
+### Optional variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NODE_ENV` | `development` | Environment mode |
+| `PORT` | `3000` | Server port |
+| `ZM_SERVICE_CODES` | `*1234#` | USSD service codes, comma-separated |
+| `IXO_API_URL` | `https://api.ixo.world` | IXO API endpoint |
+| `IXO_BLOCKCHAIN_URL` | `https://rpc.ixo.world` | IXO blockchain RPC |
+
+To target the IXO testnet instead of mainnet:
+
+```bash
+IXO_API_URL=https://api.testnet.ixo.world
+IXO_BLOCKCHAIN_URL=https://rpc.testnet.ixo.world
+```
+
+## Step 3 — Set up the database and start the server
+
+Create a PostgreSQL database, run migrations, then start the development server.
+
+```bash
+# Build the project
+pnpm build
+
+# Run database migrations
+node dist/src/migrations/run-migrations.js
+
+# Start the development server
+pnpm dev
+```
+
+The server starts at `http://localhost:3000` by default.
+
+## Step 4 — Connect a telecom gateway
+
+Most telecom USSD gateways send HTTP POST requests with form-encoded or JSON body. The IXO USSD gateway expects JSON at `POST /api/ussd`.
+
+For Africa's Talking, add a callback URL pointing to your server and adapt the request format:
+
+```javascript
+// Convert Africa's Talking format and forward to the gateway
+app.post('/ussd', async (req, res) => {
+  const response = await fetch('http://your-server/api/ussd', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sessionId: req.body.sessionId,
+      serviceCode: req.body.serviceCode,
+      phoneNumber: req.body.phoneNumber,
+      text: req.body.text || ''
+    })
+  });
+  const ussdResponse = await response.text();
+  res.type('text/plain').send(ussdResponse);
+});
+```
+
+See the [USSD gateway API reference](/api-reference/ussd-api) for the full request and response format.
+
+## Step 5 — Verify the result
+
+Send a test request to confirm the server is accepting sessions.
+
+```bash
+curl -X POST http://localhost:3000/api/ussd \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sessionId": "test-session-001",
+    "serviceCode": "*1234#",
+    "phoneNumber": "+260971234567",
+    "text": ""
+  }'
+```
+
+A working server returns a `CON` response with the main menu text.
+
+Check active sessions:
+
+```bash
+curl http://localhost:3000/api/ussd/sessions
+```
+
+Check server health:
+
+```bash
+curl http://localhost:3000/health
+```
+
+## Troubleshooting
+
+### Database connection failed
+
+Confirm PostgreSQL is running and the `DATABASE_URL` in `.env` matches your setup.
+
+```bash
+# macOS
+brew services start postgresql
+
+# Ubuntu/Debian
+sudo systemctl start postgresql
+```
+
+### Missing PIN encryption key error
+
+Generate a valid key and add it to `.env`:
+
+```bash
+echo "PIN_ENCRYPTION_KEY=$(openssl rand -hex 16)" >> .env
+```
+
+### IXO account does not exist on chain
+
+New user accounts need a small token balance to cover gas fees before the gateway can write on-chain. Update your IXO feegrant configuration to cover gas for new accounts, or send a small amount to the generated address.
+
+### Migration failed
+
+Ensure the database exists and the user has write permissions, then re-run:
+
+```bash
+pnpm build && node dist/src/migrations/run-migrations.js
+```
+
+## Next steps
+
+- [USSD gateway API reference](/api-reference/ussd-api) — request and response format, session endpoints, error codes
+- [IXO USSD gateway — architecture overview](/articles/ixo-ussd) — state machine design and integration model
+- [Architecture patterns guide](https://github.com/ixoworld/ixo-ussd/blob/main/docs/ARCHITECTURE_PATTERNS_GUIDE.md) — how to build custom USSD flows
+- [IXO networks and endpoints](/reference/networks-and-endpoints) — mainnet and testnet connection details

--- a/guides/users/ussd.mdx
+++ b/guides/users/ussd.mdx
@@ -1,0 +1,91 @@
+---
+title: "Use IXO services via USSD"
+icon: "mobile"
+description: "How to access IXO services on any basic mobile phone using USSD — no smartphone or internet required."
+---
+
+## Before you start
+
+- Any mobile phone with GSM connectivity (no smartphone or data plan needed)
+- Your phone number registered with a local mobile network
+- The USSD service code for your programme — ask your programme operator or field agent if you are unsure
+
+## What this guide does
+
+This guide explains how to access IXO services through USSD menus on a basic mobile phone. USSD lets you dial a short code and navigate menus using number keys — similar to checking your airtime balance.
+
+Through USSD you can register your identity, manage your account, report activities, and access digital vouchers — all without a smartphone or internet connection.
+
+## Step 1 — Dial the service code
+
+On your mobile phone, open the keypad and dial the USSD service code provided by your programme, then press the call button.
+
+```
+*1234#  [CALL]
+```
+
+The service code varies by programme and country. Your field agent or programme operator will confirm the correct code for your area.
+
+After dialling you will see the main menu on your phone screen within a few seconds.
+
+## Step 2 — Navigate the menus
+
+Use the number keys to select options and confirm with the call or send button. Use `0` to go back to the previous menu and `*` to exit the session.
+
+The main menu typically includes options to:
+- Learn more about the programme
+- Access your account
+- Report an activity
+- Check your status or balance
+
+Each menu screen shows the available options and a prompt for your input.
+
+## Step 3 — Create your account
+
+If this is your first time, select the account creation option from the main menu.
+
+You will be asked to:
+
+1. Enter your name
+2. Choose a PIN (kept private — do not share it)
+3. Confirm your PIN
+
+Once complete, the system creates your digital identity and account on the IXO network. You will receive a confirmation message on screen.
+
+<Warning>
+Keep your PIN private. Programme staff will never ask for your PIN.
+</Warning>
+
+## Step 4 — Report an activity or check your status
+
+After creating your account, you can return at any time to:
+
+- Report an activity (such as using a clean cooking device)
+- Check your account balance or credential status
+- Access a digital voucher
+
+Select the relevant option from the main menu, follow the prompts, and confirm with your PIN when asked.
+
+## Troubleshooting
+
+### The menu does not appear after dialling
+
+- Check that you have GSM network coverage
+- Try again after a few seconds — USSD sessions can be delayed on congested networks
+- Confirm the service code with your programme operator
+
+### The session ended before I finished
+
+USSD sessions time out after a period of inactivity (typically 30 to 60 seconds depending on your network). Dial the code again to start a new session. Your account data is saved.
+
+### I forgot my PIN
+
+Contact your programme operator or field agent. They can assist with account recovery through your registered phone number.
+
+### I see an error message
+
+If you see "Service temporarily unavailable", the server may be briefly offline. Try again after a few minutes. If the problem persists, contact your programme operator.
+
+## Next steps
+
+- [IXO USSD gateway overview](/articles/ixo-ussd) — how the USSD gateway works for operators and developers

--- a/models/itmo-context.json
+++ b/models/itmo-context.json
@@ -1,11 +1,5 @@
 {
     "@context": [
-      /* 
-        This reference points to itself, allowing JSON-LD processors
-        to correctly resolve "itmo" as a prefix within this context file.
-        You can also include additional custom contexts or references 
-        if needed for cross-context relationships.
-      */
       {
         "@version": 1.1
       },
@@ -251,8 +245,6 @@
         "schema:domainIncludes": {
           "@id": "itmo:ITMOCredential"
         }
-        /* Range can be an array of numbers or an object describing annual data, 
-           so no strict schema:rangeIncludes is applied here. */
       },
       {
         "@id": "itmo:annualCorrespondingAdjustments",
@@ -316,7 +308,6 @@
         "schema:domainIncludes": {
           "@id": "itmo:ITMOCredential"
         }
-        /* Could be a list of items, so no strict range is applied here. */
       },
       {
         "@id": "itmo:partyStatusUnderParis",
@@ -350,7 +341,6 @@
         "schema:domainIncludes": {
           "@id": "itmo:ITMOCredential"
         }
-        /* Could be an array of URLs or text references. */
       },
       {
         "@id": "itmo:mostRecentNationalInventory",

--- a/platforms/Emerging/intro-emerging.mdx
+++ b/platforms/Emerging/intro-emerging.mdx
@@ -87,6 +87,13 @@ The **Emerging Platform** is the reusable IXO platform layer for digital identit
 
 ## Integration tools
 
+### Access channels
+<CardGroup>
+  <Card title="USSD" icon="tower-cell" href="/platforms/Emerging/ussd-channel">
+    Offline mobile access for rural households via USSD — no smartphone required
+  </Card>
+</CardGroup>
+
 ### Device Integration
 <CardGroup>
   <Card title="Client SDK" icon="box" href="/spatial-web-stack/spatial-web-sdks">

--- a/platforms/Emerging/ussd-channel.mdx
+++ b/platforms/Emerging/ussd-channel.mdx
@@ -1,0 +1,25 @@
+---
+title: "USSD access channel"
+icon: "tower-cell"
+description: "How Emerging Household Energy uses USSD to give rural households offline access to IXO services."
+---
+
+Emerging Household Energy uses USSD as the primary offline access channel for rural household members. It is built on the open-source [IXO USSD gateway](/articles/ixo-ussd) and deployed as a fork at [emerging-eco/ixo-ussd-supamoto](https://github.com/emerging-eco/ixo-ussd-supamoto).
+
+Users dial a USSD short code on any GSM phone — no smartphone or data plan required — to register their identity, manage their account, and interact with Emerging Household Energy services.
+
+## Current capabilities
+
+The Supamoto deployment supports:
+
+- **Know More** — information about the programme, products, and services
+- **Account creation** — register a new household member identity with a PIN, creating an IXO Decentralized Identifier (DID) and on-chain wallet
+- **Account login** — authenticate returning users by phone number and PIN
+
+Additional flows, including user services and agent services, are under active development. See the [repository](https://github.com/emerging-eco/ixo-ussd-supamoto) for current status.
+
+## Related pages
+
+- [IXO USSD gateway](/articles/ixo-ussd) — generic gateway architecture and how USSD connects to IXO Protocol
+- [Deploy the IXO USSD gateway](/guides/dev/ussd-gateway) — set up and configure the gateway
+- [Emerging Household Energy digital identifiers](/platforms/Emerging/digital-identifiers) — how DIDs and credentials are used for household members


### PR DESCRIPTION
## Summary

- **4 new USSD pages**: concept article, developer setup guide, API reference, end-user guide — all grounded in the `ixoworld/ixo-ussd` source repo
- **Emerging Platform**: new `ussd-channel.mdx` page for Supamoto deployment, light-touch cross-links in `intro-emerging.mdx` and `articles/intro-platforms.mdx`
- **Developer nav restructured**: `guides/dev/spatial-web-sdks` renamed to "IXO SDKs and tools" with canonical SDK names and new Gateway tools section; Developers group restructured with Developer Guides subgroup; `guides/dev/overview` restored as nav home with deprecated code and "Spatial Web" language removed
- **Bug fix**: removed invalid JS block comments from `models/itmo-context.json` that were preventing the Mintlify dev server from starting

## Pages changed

| File | Change |
|---|---|
| `articles/ixo-ussd.mdx` | New — USSD gateway concept/overview article |
| `guides/dev/ussd-gateway.mdx` | New — developer setup and deployment guide |
| `api-reference/ussd-api.mdx` | New — USSD session endpoint reference |
| `guides/users/ussd.mdx` | New — end-user guide |
| `platforms/Emerging/ussd-channel.mdx` | New — Emerging Household Energy USSD access channel |
| `guides/dev/spatial-web-sdks.mdx` | Rewritten — canonical names, Gateway tools section added |
| `guides/dev/overview.mdx` | Rewritten — clean navigator, no unverified code |
| `api-reference/index.mdx` | USSD gateway API card added |
| `articles/intro-platforms.mdx` | USSD card added to User Interfaces |
| `platforms/Emerging/intro-emerging.mdx` | USSD access channels section added |
| `models/itmo-context.json` | Invalid JS comments removed |
| `docs.json` | Nav wired for all new pages; Developers group restructured |

## Test plan

- [x] Mintlify dev server starts without errors (`mintlify dev`)
- [x] All 4 new USSD pages render at their expected routes
- [ ] `platforms/Emerging/ussd-channel` is reachable from Platforms tab nav
- [x] Developers group shows "Developer Guides" subgroup with correct pages
- [x] All internal links in new pages resolve
- [x] USSD card on `guides/dev/spatial-web-sdks` links to `articles/ixo-ussd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)