### PR TITLE
[codex] consolidate SDK entrypoint and canonical link usage

### DIFF
--- a/.codex/REDIRECTS_AND_DEPRECATIONS.md
+++ b/.codex/REDIRECTS_AND_DEPRECATIONS.md
@@ -4,6 +4,10 @@ Use this file whenever a docs route, page label, or public surface name changes.
 
 ## General rules
 
+### Canonical links first
+Always update docs content to link directly to the canonical destination route.
+Treat redirects and stubs as compatibility layers for legacy/external traffic, not as an internal linking strategy.
+
 ### Prefer stable routes
 If a misleading page can be corrected by:
 - changing the H1,
@@ -22,7 +26,7 @@ Change a route only if the current route is:
 ## When a route changes
 
 1. Add an entry to the ledger below.
-2. Update all internal links.
+2. Update all internal links to the new canonical route.
 3. Update `docs.json`.
 4. Add a redirect or a short deprecation stub if the platform supports it.
 5. Mention the route change in the task summary.
@@ -50,19 +54,19 @@ Example:
 
 | Status | Old route | New route | Reason | Notes |
 |---|---|---|---|---|
-| changed | `/sdk-reference/oracle-ai-sdk` | `/sdk-reference/oracle-adk` | ADK slug for Personal Agent ADK (`@ixo/assistant-sdk`) | Redirect configured in `docs.json` |
+| changed | `/sdk-reference/oracle-ai-sdk` | `/sdk-reference/oracle-adk` | ADK slug for Personal Agent ADK (`@ixo/assistant-sdk`) | Internal links use canonical route; compatibility redirect retained in `docs.json` |
 | accepted (stable route) | `/mcp/model-context-protocol` | keep existing route | H1 and body fixes are sufficient without slug migration | Prefer stable route first |
 | changed | `/articles/ixo-protocol` | `/protocols/ixo-protocol` | Protocol concept docs consolidated under canonical `protocols/` directory | Internal links and nav updated |
 | changed | `/articles/ixo-blockchain` | `/protocols/ixo-protocol` | Duplicate IXO Protocol concept page removed in favor of one canonical protocol page | Internal links and nav updated |
 | deprecated (stub) | `/api-docs/*` | canonical `api-reference/*` routes | Legacy API docs tree replaced with transitional stubs | Stubs point to closest canonical API or guide route by topic |
-| changed | `/spatial-web-stack/*` | `/ixo-stack/*` | Canonical stack route namespace normalized to IXO naming | Directory renamed, internal links updated, and explicit redirects added in `docs.json` |
-| changed | `/ixo-stack/sdks/oracle-agent-sdk`, `/spatial-web-stack/sdks/oracle-agent-sdk` | `/sdk-reference/oracles-client-sdk` | Old route represented the client-facing oracle interface, now mapped to the canonical Oracles Client SDK page | Redirects updated in `docs.json`; ADK remains canonical at `/sdk-reference/agentic-oracles-adk` for service-side scaffolding/deployment |
+| changed | `/spatial-web-stack/*` | `/ixo-stack/*` | Canonical stack route namespace normalized to IXO naming | Directory renamed, internal links updated to canonical routes, compatibility redirects retained in `docs.json` |
+| changed | `/ixo-stack/sdks/oracle-agent-sdk`, `/spatial-web-stack/sdks/oracle-agent-sdk` | `/sdk-reference/oracles-client-sdk` | Old route represented the client-facing oracle interface, now mapped to the canonical Oracles Client SDK page | Internal links use canonical route; ADK remains canonical at `/sdk-reference/agentic-oracles-adk` for service-side scaffolding/deployment |
 | changed | `/ixo-stack/sdks/ixo-matrix-sdk`, `/spatial-web-stack/sdks/ixo-matrix-sdk` | `/sdk-reference/matrix-client-sdk` | Legacy SDK stub replaced with direct redirect to Matrix Client SDK reference | Internal MDX links updated |
 | changed | `/ixo-stack/sdks/intro-sdks`, `/spatial-web-stack/sdks/intro-sdks` | `/sdk-reference/index` | Legacy IXO Stack SDK intro stub replaced with direct redirect to SDK reference index | Internal MDX links updated |
 | changed | `/ixo-stack/sdks/signx-sdk`, `/spatial-web-stack/sdks/signx-sdk` | `/sdk-reference/signx-sdk` | Legacy stub redirected to SignX SDK reference | Stubs retained as pointers |
 | changed | `/ixo-stack/sdks/jambo-wallet-sdk`, `/spatial-web-stack/sdks/jambo-wallet-sdk` | `/sdk-reference/jambo-wallet-sdk` | Legacy stub redirected to JAMBO PWA SDK reference | Stubs retained as pointers |
 | changed | `/ixo-stack/sdks/ixo-multiclient-sdk`, `/spatial-web-stack/sdks/ixo-multiclient-sdk` | `/sdk-reference/multiclient-sdk` | Legacy stub redirected to MultiClient SDK reference | Stubs retained as pointers |
-| changed | `/guides/dev/spatial-web-sdks` | `/guides/dev/ixo-stack-sdks` | Developer SDK hub slug aligned to IXO Stack naming | Redirect configured in `docs.json`; file renamed to `guides/dev/ixo-stack-sdks.mdx` |
+| changed | `/guides/dev/spatial-web-sdks` | `/guides/dev/ixo-stack-sdks` | Developer SDK hub slug aligned to IXO Stack naming | Internal links use canonical route; compatibility redirect retained in `docs.json` |
 | added | n/a | `/reference/networks-and-endpoints` | Establish canonical home for endpoint and network literals | New reference route |
 | added | n/a | `/reference/authentication-matrix` | Establish canonical home for auth headers and surface-level auth ownership | New reference route |
 | added | n/a | `/reference/product-and-sdk-map` | Establish canonical home for product-to-SDK naming and route mapping | New reference route |

--- a/guides/dev/ixo-domains.mdx
+++ b/guides/dev/ixo-domains.mdx
@@ -304,8 +304,8 @@ description: 'Create and manage digital domains for entities on the IXO Stack'
     Entity module API documentation
   </Card>
   
-  <Card title="SDK Guide" icon="code" href="/guides/dev/ixo-stack-sdks">
-    Client SDK implementation guide
+  <Card title="SDK and kit overview" icon="code" href="/sdk-reference/index">
+    Canonical SDK guide and routing map
   </Card>
   
   <Card title="Examples" icon="lightbulb" href="/guides/dev/examples">

--- a/guides/dev/ixo-stack-sdks.mdx
+++ b/guides/dev/ixo-stack-sdks.mdx
@@ -1,167 +1,63 @@
 ---
 title: 'IXO Stack SDKs'
 icon: 'code'
-description: 'Build advanced applications on the IXO Stack using the comprehensive suite of IXO development tools'
+description: 'Developer entry point to SDK workflows, with the canonical SDK and kit overview in the SDK reference'
 ---
 
-<Tip>
-The IXO Stack SDKs help you integrate the IXO Protocol, IXO Matrix, and related services from TypeScript. Deployable **gateway tools** extend IXO to offline and mobile channels (including USSD).
-</Tip>
+<Info>
+The canonical SDK and kit overview is now maintained at [IXO and Qi Developer Kits](/sdk-reference/index).  
+Use this page as a developer workflow entry point.
+</Info>
 
-## Available SDKs
-
-<CardGroup>
-
-<Card title="IXO MultiClient SDK" icon="network-wired" href="/sdk-reference/multiclient-sdk">
-  Connect with IXO and Cosmos networks for interchain operations
-</Card>
-
-<Card title="Matrix Client SDK" icon="database" href="/sdk-reference/matrix-client-sdk">
-  Build secure data rooms and encrypted communication channels
-</Card>
-
-<Card title="Agentic Oracles ADK" icon="sparkles" href="/sdk-reference/agentic-oracles-adk">
-  Build oracle and agent services with `@ixo/oracle-agent-sdk`
-</Card>
-
-<Card title="Personal Agent ADK" icon="brain" href="/sdk-reference/oracle-adk">
-  Integrate conversational AI with `@ixo/assistant-sdk`
-</Card>
-
-<Card title="JAMBO PWA SDK" icon="wallet" href="/sdk-reference/jambo-wallet-sdk">
-  Manage digital assets and credentials in JAMBO PWA experiences
-</Card>
-
-<Card title="SignX SDK" icon="signature" href="/sdk-reference/signx-sdk">
-  Enable secure mobile-to-web authentication and transaction signing
-</Card>
-
-</CardGroup>
-
-## Gateway tools
-
-Fork or deploy these tools to extend IXO services to additional channels and environments.
+## Start here
 
 <CardGroup>
-
-<Card title="IXO USSD gateway" icon="tower-cell" href="/articles/ixo-ussd">
-  Give any GSM mobile phone access to IXO services — no smartphone or data plan required
-</Card>
-
+  <Card title="SDK and kit overview (canonical)" icon="book" href="/sdk-reference/index">
+    Choose the right SDK or kit, including Oracles Client SDK, Agentic Oracles ADK, and JAMBO PWA SDK.
+  </Card>
+  <Card title="Developer workflows" icon="diagram-project" href="/guides/dev/workflows">
+    Follow end-to-end implementation patterns for entities, claims, evaluation, and integrations.
+  </Card>
+  <Card title="Identity and credentials" icon="id-card" href="/guides/dev/identity-and-credentials">
+    Understand DID, claim, and credential relationships used across SDK workflows.
+  </Card>
+  <Card title="API reference" icon="code" href="/api-reference/index">
+    Review service and infrastructure APIs used by SDK-based implementations.
+  </Card>
 </CardGroup>
 
-## Installation
+## SDK quick links
 
-```bash
-# Install core SDKs
-npm install @ixo/impactxclient-sdk @ixo/matrixclient-sdk
-npm install @ixo/assistant-sdk @ixo/jambo-wallet-sdk
-```
-
-## Basic Setup
-
-<CodeGroup>
-
-```typescript IXO MultiClient SDK
-import { createClient } from "@ixo/impactxclient-sdk";
-
-// Initialize client
-const chain = await createClient({
-  rpcEndpoint: RPC_ENDPOINT,
-  chainId: "ixo-5"
-});
-
-// Create digital twin
-const twin = await chain.entity.create({
-  type: "DigitalTwin",
-  controller: "did:ixo:org/123"
-});
-```
-
-```typescript IXO Matrix Client SDK
-import { createMatrixClient } from "@ixo/matrixclient-sdk";
-
-// Initialize Matrix client
-const matrix = await createMatrixClient({
-  baseUrl: MATRIX_ENDPOINT,
-  accessToken: USER_TOKEN
-});
-
-// Create secure data room
-const room = await matrix.createRoom({
-  name: "Secure Data Room",
-  encryption: true,
-  visibility: "private"
-});
-```
-
-```typescript Assistant
-import { createAssistant } from "@ixo/assistant-sdk";
-
-// Initialize assistant
-const assistant = await createAssistant({
-  type: "VerificationAgent",
-  capabilities: ["verification", "analytics"]
-});
-
-// Process verification request
-const result = await assistant.verify({
-  data: inputData,
-  context: verificationContext
-});
-```
-
-```typescript JAMBO PWA
-import { createWallet } from "@ixo/jambo-wallet-sdk";
-
-// Initialize wallet
-const wallet = await createWallet({
-  storageType: "secure",
-  network: "mainnet"
-});
-
-// Manage credentials
-const credential = await wallet.createCredential({
-  type: "VerifiableCredential",
-  issuer: "did:ixo:issuer/123"
-});
-```
-
-</CodeGroup>
-
-## End-to-end workflows
-
-For runnable patterns (client setup, entities, claims, evaluation) aligned with [Implementation examples](/guides/dev/examples), read [Developer workflows](/guides/dev/workflows). For DID, claim, and VC relationships, read [Identity and credentials](/guides/dev/identity-and-credentials).
-
-## Key Features
-
-### MultiClient SDK
-- Interchain transactions and queries
-- Digital twin management
-- Entity state management
-- Blockchain service management
-
-### Matrix Client SDK
-- End-to-end encrypted data rooms
-- Secure messaging and file storage
-- Access control management
-- Real-time data streaming
-
-### Personal Agent ADK
-- AI-powered agent services
-- Analytics processing
-- Evidence collection
-- Proof generation
-
-### JAMBO PWA SDK
-- Credential management
-- Digital asset operations
-- Secure key storage
-- Transaction signing
+<CardGroup cols={2}>
+  <Card title="IXO MultiClient SDK" icon="network-wired" href="/sdk-reference/multiclient-sdk">
+    Interchain protocol interactions and entity workflows.
+  </Card>
+  <Card title="IXO Matrix Client SDK" icon="database" href="/sdk-reference/matrix-client-sdk">
+    Encrypted rooms, messaging, and shared state integrations.
+  </Card>
+  <Card title="Oracles Client SDK" icon="comments" href="/sdk-reference/oracles-client-sdk">
+    Frontend agent-client interfaces for deployed oracles.
+  </Card>
+  <Card title="Agentic Oracles ADK" icon="sparkles" href="/sdk-reference/agentic-oracles-adk">
+    Scaffold, implement, and deploy oracle services.
+  </Card>
+  <Card title="Personal Agent ADK" icon="brain" href="/sdk-reference/oracle-adk">
+    Personal conversational assistant integrations.
+  </Card>
+  <Card title="JAMBO PWA SDK" icon="wallet" href="/sdk-reference/jambo-wallet-sdk">
+    JAMBO PWA integrations with wallet-enabled workflows.
+  </Card>
+  <Card title="IXO SignX SDK" icon="signature" href="/sdk-reference/signx-sdk">
+    User authentication and transaction signing flows.
+  </Card>
+  <Card title="IXO USSD gateway" icon="tower-cell" href="/articles/ixo-ussd">
+    Extend IXO services to offline and feature-phone channels.
+  </Card>
+</CardGroup>
 
 ## Next steps
 
-- [Developer workflows](/guides/dev/workflows) — SDK patterns for domains, claims, and verification
-- [SDK reference](/sdk-reference) — full reference for each SDK
-- [API reference](/api-reference) — IXO service APIs
-- [Developer overview](/guides/dev/overview) — entry points and task-oriented guides
+- [IXO and Qi Developer Kits](/sdk-reference/index) — canonical SDK and kit overview
+- [Developer workflows](/guides/dev/workflows) — implementation patterns for domains, claims, and verification
+- [API reference](/api-reference/index) — IXO service APIs
+- [Developer overview](/guides/dev/overview) — task-oriented entry points

--- a/guides/dev/overview.mdx
+++ b/guides/dev/overview.mdx
@@ -13,7 +13,7 @@ description: 'Build AI-operable workflows on IXO: SDKs, APIs, and paths from sha
 ## Choose your starting point
 
 <CardGroup>
-  <Card title="SDKs and tools" icon="toolbox" href="/guides/dev/ixo-stack-sdks">
+  <Card title="SDKs and tools" icon="toolbox" href="/sdk-reference/index">
     Browse TypeScript SDKs and deployable gateway tools, including the IXO MultiClient SDK, IXO Matrix Client SDK, and IXO USSD gateway
   </Card>
   <Card title="API reference" icon="server" href="/api-reference">

--- a/guides/dev/workflows.mdx
+++ b/guides/dev/workflows.mdx
@@ -130,8 +130,8 @@ For HTTP-oriented credential flows on Emerging, use the platform API docs ([Emer
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="IXO Stack SDKs" icon="toolbox" href="/guides/dev/ixo-stack-sdks">
-    All SDK entry points and gateway tools
+  <Card title="SDK and kit overview" icon="toolbox" href="/sdk-reference/index">
+    Canonical SDK and kit overview with route selection guidance
   </Card>
   <Card title="MultiClient SDK" icon="server" href="/sdk-reference/multiclient-sdk">
     Module-level features on-chain

--- a/platforms/Emerging/domain-registration.mdx
+++ b/platforms/Emerging/domain-registration.mdx
@@ -210,7 +210,7 @@ query DomainStatus($did: String!) {
   <Card title="API Reference" icon="code" href="/platforms/Emerging/emerging-api">
     Domain registration endpoints
   </Card>
-  <Card title="SDK Guide" icon="box" href="/guides/dev/ixo-stack-sdks">
+  <Card title="SDK Guide" icon="box" href="/sdk-reference/index">
     Client libraries and tools
   </Card>
   <Card title="Example Projects" icon="lightbulb" href="/guides/dev/examples">

--- a/platforms/Emerging/energy-systems.mdx
+++ b/platforms/Emerging/energy-systems.mdx
@@ -131,7 +131,7 @@ graph TD
 
 ### CDT System Integrations
 <CardGroup>
-  <Card title="IoT Connectivity" icon="wifi" href="/guides/dev/ixo-stack-sdks">
+  <Card title="IoT Connectivity" icon="wifi" href="/sdk-reference/index">
     Device data streaming and control
   </Card>
   <Card title="Registry Services" icon="grid" href="/platforms/Emerging/registry">
@@ -159,7 +159,7 @@ graph TD
   <Card title="API Documentation" icon="code" href="/platforms/Emerging/emerging-api">
     Complete API reference
   </Card>
-  <Card title="SDKs" icon="box" href="/guides/dev/ixo-stack-sdks">
+  <Card title="SDKs" icon="box" href="/sdk-reference/index">
     Development tools and libraries
   </Card>
   <Card title="AI Companion" icon="sparkles" href="/guides/users/ai-companion">

--- a/platforms/Emerging/intro-emerging.mdx
+++ b/platforms/Emerging/intro-emerging.mdx
@@ -96,7 +96,7 @@ The **Emerging Platform** is the reusable IXO platform layer for digital identit
 
 ### Device Integration
 <CardGroup>
-  <Card title="Client SDK" icon="box" href="/guides/dev/ixo-stack-sdks">
+  <Card title="Client SDK" icon="box" href="/sdk-reference/index">
     Libraries for device connectivity and data streaming
   </Card>
   <Card title="Cognitive Digital Twins" icon="brain" href="/platforms/Emerging/energy-systems">

--- a/reference/product-and-sdk-map.mdx
+++ b/reference/product-and-sdk-map.mdx
@@ -37,7 +37,7 @@ Use this page as the canonical naming and routing map for product and SDK surfac
   <Accordion title="Personal Agent ADK" icon="brain">
     - **Package identifier:** `@ixo/assistant-sdk`
     - **Primary docs route:** [oracle-adk](/sdk-reference/oracle-adk)
-    - **Notes:** Public docs name for `@ixo/assistant-sdk`; `/sdk-reference/oracle-ai-sdk` redirects here.
+    - **Notes:** Public docs name for `@ixo/assistant-sdk`; use this canonical route in all docs links.
   </Accordion>
 
   <Accordion title="IXO SignX SDK" icon="key">


### PR DESCRIPTION
## Summary
- consolidate overlapping SDK documentation by converting `guides/dev/ixo-stack-sdks` into a workflow entrypoint that points to the canonical SDK overview at `/sdk-reference/index`
- normalize cross-page SDK links in developer and Emerging Platform pages so internal navigation points directly to canonical routes
- update redirect/deprecation governance wording to enforce canonical-links-first policy and keep redirects/stubs as compatibility layers only

## Test plan
- [x] Run targeted lints on edited guide, platform, reference, and governance pages
- [x] Run repo-wide search to verify no remaining internal links to `/guides/dev/ixo-stack-sdks` where canonical SDK overview is intended
- [ ] Preview updated pages in local Mintlify dev server (`guides/dev/ixo-stack-sdks`, `sdk-reference/index`, and linked Emerging pages)