### PR TITLE
docs(build-an-oracle): audit + fix all 60 pages against the runtime (IXO-3105)

### DIFF
--- a/build-an-oracle/develop/create-oracle-app.mdx
+++ b/build-an-oracle/develop/create-oracle-app.mdx
@@ -73,9 +73,9 @@ That's a working oracle — every bundled plugin runs its `autoDetect(env)` and 
     const app = await createOracleApp({
       config,
       features: {
-        composio: false,        // force off
-        firecrawl: true,        // force on, even if env is missing (will fail env validation if so)
-        domainIndexer: 'auto',  // default — runs autoDetect(env)
+        composio: false,           // force off
+        firecrawl: true,           // force on, even if env is missing (will fail env validation if so)
+        'domain-indexer': 'auto',  // default — runs autoDetect(env)
       },
     });
     ```
@@ -87,6 +87,10 @@ That's a working oracle — every bundled plugin runs its `autoDetect(env)` and 
     | `'auto'` | Default. Run `autoDetect(env)`. |
 
     Omitted keys are treated as `'auto'`. Recipe: [Enable bundled plugins](/build-an-oracle/develop/enable-bundled-plugins).
+
+    <Warning>
+      Feature keys are the plugin's kebab-case `name` — `'domain-indexer'`, `'user-preferences'`, `'matrix-group-chats'`. A camelCase key like `domainIndexer` type-checks (it falls into the open `string` arm) but is a silent no-op: the plugin keeps its default behaviour. Always quote the exact `name`.
+    </Warning>
   </Step>
 
   <Step title="Mount your own Nest modules" icon="cube">
@@ -168,6 +172,26 @@ That's a working oracle — every bundled plugin runs its `autoDetect(env)` and 
     | `degradedServicesBlock` | empty | Degraded-services notice appended to system prompt |
 
     Source: [`graph/main-agent-types.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/graph/main-agent-types.ts) (search `MainAgentHooks`).
+
+    **Change the AI model.** The most common reason to set `hooks` is to swap the model. The runtime resolves the main agent's model via `resolveModel('main')`; override it and spread `params` to keep the provider's fallback models and latency sort:
+
+    ```ts
+    import { createOracleApp, getProviderChatModel } from '@ixo/oracle-runtime';
+
+    const app = await createOracleApp({
+      config,
+      hooks: {
+        // role is 'main' | 'subagent' | 'utility' | (string & {}).
+        resolveModel: (role, params) =>
+          getProviderChatModel(role, {
+            ...params,
+            ...(role === 'main' && { model: 'google/gemini-3.1-flash-lite' }),
+          }),
+      },
+    });
+    ```
+
+    The provider (`LLM_PROVIDER` = `openrouter` default | `nebius`) and per-role default model ids are otherwise fixed in the runtime — there is no env var to change the main model id without this hook. You can also return any LangChain `BaseChatModel` (e.g. `new ChatOpenAI({ model: 'gpt-4o' })`), but doing so drops the OpenRouter fallback/latency wiring.
   </Step>
 
   <Step title="Run a beforeListen hook" icon="play">
@@ -201,16 +225,16 @@ That's a working oracle — every bundled plugin runs its `autoDetect(env)` and 
     logger.log(`[boot] loaded: ${status.loaded.join(', ')}`);
     ```
 
-    `onPluginStatusChange` fires when Matrix transitions `pending → loaded` (or `failed`). `onError` catches Matrix init + lifecycle errors. `plugins.status()` returns the same shape `qiforge inspect` prints.
+    `onPluginStatusChange` fires when Matrix transitions `pending → loaded` (or `failed`). `onError` catches Matrix init + lifecycle errors. `plugins.status()` returns a snapshot of loaded, excluded, and soft-dep-gap plugins.
   </Step>
 
   <Step title="Listen" icon="rocket">
     ```ts
-    await app.listen();        // honours config.PORT, env.PORT, then 5678
-    await app.listen(3000);    // explicit port
+    await app.listen();        // uses the PORT env var (defaults to 3000)
+    await app.listen(8080);    // explicit port — overrides PORT
     ```
 
-    Calling `listen()` twice throws. Default port is **5678** — set `PORT` env or pass a number to override.
+    Calling `listen()` twice throws. Default port is **3000** — set the `PORT` env var or pass a number to `listen()` to override.
   </Step>
 </Steps>
 

--- a/build-an-oracle/develop/deploy.mdx
+++ b/build-an-oracle/develop/deploy.mdx
@@ -24,7 +24,7 @@ COPY package.json ./
 RUN mkdir -p /data
 ENV MATRIX_STORE_PATH=/data/matrix-storage
 ENV SQLITE_DATABASE_PATH=/data/sqlite
-EXPOSE 5678
+EXPOSE 3000
 CMD ["node", "dist/main.js"]
 ```
 
@@ -55,7 +55,7 @@ Everything below explains the moving parts. The reference oracle (`apps/qiforge-
 
     ```text
     NODE_ENV=production
-    PORT=5678
+    PORT=3000
     ORACLE_NAME=My Oracle
     CORS_ORIGIN=https://your-portal.example
     NETWORK=mainnet
@@ -66,6 +66,10 @@ Everything below explains the moving parts. The reference oracle (`apps/qiforge-
     SECP_MNEMONIC=...
     RPC_URL=https://rpc.ixo.world
     BLOCKSYNC_GRAPHQL_URL=https://blocksync.ixo.world/graphql
+
+    # Auth tuning (optional — safe defaults)
+    UCAN_AUTH_MAX_TTL_SECONDS=900               # max accepted lifetime of a user auth invocation (default 15 min)
+    UCAN_REAUTH_PROMPT_THROTTLE_SECONDS=21600   # gap between re-authorize prompts (default 6 hours)
 
     # Matrix
     MATRIX_BASE_URL=https://matrix.ixo.world
@@ -98,8 +102,8 @@ Everything below explains the moving parts. The reference oracle (`apps/qiforge-
     Identity and Matrix keys are provisioned via the CLI — see [identity and auth](/build-an-oracle/develop/identity-and-auth) for the full flow.
 
     ```sh
-    qiforge create-entity --no-interactive --network mainnet ...
-    qiforge setup-encryption-key
+    qiforge-cli create-entity --no-interactive --network mainnet ...
+    qiforge-cli setup-encryption-key
     ```
   </Step>
 </Steps>
@@ -159,13 +163,13 @@ Everything below explains the moving parts. The reference oracle (`apps/qiforge-
 
 <Steps>
   <Step title="Use /health as the liveness probe">
-    The framework exposes `GET /health`, always public, never goes through `AuthHeaderMiddleware`. Returns 200 once Nest is up.
+    The framework exposes `GET /health`, always public, never goes through `AuthHeaderMiddleware`. Returns 200 once Nest is up. The built-in auth-excluded routes are `/` (a JSON landing payload), `/health`, `/docs`, and `/docs/(.*)` — everything else requires auth.
 
     Docker:
 
     ```dockerfile
     HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-      CMD curl -fsS http://localhost:5678/health || exit 1
+      CMD curl -fsS http://localhost:3000/health || exit 1
     ```
 
     Kubernetes:
@@ -174,7 +178,7 @@ Everything below explains the moving parts. The reference oracle (`apps/qiforge-
     livenessProbe:
       httpGet:
         path: /health
-        port: 5678
+        port: 3000
     ```
   </Step>
 
@@ -201,8 +205,10 @@ The framework allows these headers on every request:
 ```text
 Content-Type, Authorization,
 x-ucan-delegation, x-matrix-access-token, x-matrix-homeserver,
-x-did, x-request-id, x-timezone
+x-did, x-request-id, x-auth-type, x-timezone
 ```
+
+`Authorization` and `x-auth-type` carry the primary invocation-auth path (`Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`); `x-ucan-delegation` carries the downstream-authorization delegation. If you replicate CORS at a reverse proxy, mirror this full list — dropping `x-auth-type` breaks browser clients on the primary auth path.
 
 ## Logging
 
@@ -212,7 +218,9 @@ For structured tracing instead of free-form logs, set the LangSmith env vars —
 
 ## Graceful shutdown
 
-The runtime registers a `SIGTERM` / `SIGINT` handler that closes the Nest app and disconnects Matrix.
+The runtime registers a `SIGTERM` / `SIGINT` handler that drains in order: (1) **flushes the per-user checkpoint to Matrix**, (2) closes the Nest app, (3) shuts down the Matrix client, (4) runs any plugin teardowns. Each step is isolated — a failure in one is logged and the rest still run.
+
+That first step is why a clean `SIGTERM` matters: an abrupt `SIGKILL` skips the checkpoint upload and loses recent thread state. See [`graceful-shutdown.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/bootstrap/graceful-shutdown.ts).
 
 ```ts
 // To disable (rare — only when your platform's process manager
@@ -224,7 +232,7 @@ const app = await createOracleApp({
 ```
 
 <Warning>
-Disable graceful shutdown only when your platform's process manager guarantees a clean `app.close()` on termination. Otherwise you'll get partial flushes and Matrix sync corruption.
+Disable graceful shutdown only when your platform's process manager guarantees a clean `app.close()` on termination. Otherwise you'll skip the checkpoint flush and risk Matrix sync corruption.
 </Warning>
 
 ## Where to read next

--- a/build-an-oracle/develop/enable-bundled-plugins.mdx
+++ b/build-an-oracle/develop/enable-bundled-plugins.mdx
@@ -67,7 +67,7 @@ Each plugin's `autoDetect` predicate decides whether to opt in when you leave it
 
 | Plugin | Auto-detects when | Notes |
 | --- | --- | --- |
-| `memory` | `MEMORY_MCP_URL` and `MEMORY_ENGINE_URL` set | Visibility `always` |
+| `memory` | `MEMORY_MCP_URL` set | Visibility `always` |
 | `portal` | always on | Visibility `on-demand` |
 | `firecrawl` | `FIRECRAWL_MCP_URL` set | Visibility `on-demand` |
 | `domain-indexer` | always on | Visibility `always` |
@@ -77,9 +77,9 @@ Each plugin's `autoDetect` predicate decides whether to opt in when you leave it
 | `editor` | always on | Needs `matrixClient` — instantiate explicitly |
 | `agui` | always on | Visibility `on-demand` |
 | `slack` | `SLACK_BOT_OAUTH_TOKEN` set | Visibility `silent` (transport) |
-| `tasks` | `REDIS_URL` set | Stub |
+| `tasks` | `REDIS_URL` set | Visibility `on-demand`; BullMQ-backed async tasks (needs `REDIS_URL`) |
 | `credits` | always on | Visibility `silent`; pass `redis` for production |
-| `calls` | always on | Stub |
+| `calls` | always on | Visibility `silent`; placeholder stub (no tools yet) |
 | `user-preferences` | always on | Visibility `always` |
 | `matrix-group-chats` | always on | Visibility `on-demand`; gating middleware + tools fire only in Matrix group rooms (`memberCount > 2`) |
 
@@ -176,22 +176,14 @@ The bundled `editorPlugin` and `creditsPlugin` instances boot in stub form (for 
     // {
     //   loaded: ['memory', 'domain-indexer', 'editor', 'user-preferences', 'weather'],
     //   excluded: [
-    //     { plugin: 'composio', reason: 'auto-detect precondition not met (COMPOSIO_API_KEY)', cause: 'auto_detect_missing' },
-    //     { plugin: 'slack',    reason: 'feature flag set to false',                              cause: 'feature_false' },
+    //     { plugin: 'composio', reason: 'auto-detect precondition not met (COMPOSIO_API_KEY)' },
+    //     { plugin: 'slack',    reason: 'feature flag set to false' },
     //   ],
     //   softDepGaps: [],
     // }
     ```
 
-    `cause` is one of `'feature_false'`, `'auto_detect_missing'`, `'cascaded'`. Surface this in your boot logs so operators see what came up.
-  </Step>
-
-  <Step title="Or use the CLI">
-    ```sh
-    qiforge inspect
-    ```
-
-    Same data, formatted for the terminal. See the [CLI reference](/build-an-oracle/reference/cli).
+    Each `excluded` entry is `{ plugin, reason }` — surface the `reason` in your boot logs so operators see why a plugin came up missing. (`softDepGaps` entries are `{ plugin, missing }`.)
   </Step>
 </Steps>
 

--- a/build-an-oracle/develop/identity-and-auth.mdx
+++ b/build-an-oracle/develop/identity-and-auth.mdx
@@ -27,29 +27,33 @@ The `OracleConfig` type lives in [`packages/oracle-runtime/src/plugin-api/types.
 | Layer | What it is | Where it comes from |
 | --- | --- | --- |
 | **Oracle identity** | DID + Matrix bot user + on-chain entity | `OracleConfig` (inline) + `ORACLE_DID` / `ORACLE_ENTITY_DID` / `MATRIX_ORACLE_ADMIN_*` env vars |
-| **User identity** | Per-request DID + UCAN capabilities | Headers on every incoming request (`x-ucan-delegation`, `x-did`, ...) |
+| **User identity** | Per-request DID + UCAN capabilities | Headers on every incoming request — a user-signed UCAN invocation (`Authorization: Bearer …` + `X-Auth-Type: ucan`) for authentication, plus `x-ucan-delegation` for downstream authorization |
 
 ## One-time oracle setup
 
 <Steps>
   <Step title="Run the CLI to create the oracle's on-chain entity and Matrix account">
     ```sh
-    qiforge create-entity --no-interactive \
+    qiforge-cli create-entity --no-interactive \
       --network devnet \
       --oracle-name "My Oracle" \
       --org-name "My Org" \
-      --api-url http://localhost:5678 \
+      --api-url http://localhost:3000 \
       --model "anthropic/claude-sonnet-4"
     ```
 
     This creates a blockchain entity (`did:ixo:entity:...`), registers linked resources, provisions a Matrix bot account, and writes both `oracle.config.json` and `.env`. Run once per deployment — subsequent deploys reuse the identity.
+
+    <Note>
+    `create-entity` registers `--api-url http://localhost:4000` by default, but the runtime's own default `PORT` is `3000` (the example above pins the URL to `:3000` to match). If you take the default URL instead, make your oracle reachable at it: either set `PORT=4000` in `.env`, or change the registered URL later with `qiforge-cli update-oracle-api-url`.
+    </Note>
 
     See the [CLI reference](/build-an-oracle/reference/cli) for every flag.
   </Step>
 
   <Step title="Provision the encryption key for per-room secrets">
     ```sh
-    qiforge setup-encryption-key
+    qiforge-cli setup-encryption-key
     ```
 
     Sets up the P-256 keyAgreement on the oracle's Matrix account room. Without this, the secrets read path returns nothing (acceptable degraded mode for routes that don't need it).
@@ -76,6 +80,15 @@ The `OracleConfig` type lives in [`packages/oracle-runtime/src/plugin-api/types.
     ```
 
     The runtime validates all of these at boot via [`baseEnvSchema`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/config/base-env-schema.ts); missing vars fail with a clear message.
+
+    Two auth-tuning vars have safe defaults — set them only to override:
+
+    ```text
+    UCAN_AUTH_MAX_TTL_SECONDS=900           # max lifetime the oracle accepts for a user auth invocation (default 15 min)
+    UCAN_REAUTH_PROMPT_THROTTLE_SECONDS=21600  # min gap between "please re-authorize" prompts (default 6 hours)
+    ```
+
+    `UCAN_AUTH_MAX_TTL_SECONDS` bounds the replay window server-side regardless of the TTL the client declares; `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS` keeps a de-authorized user from being nagged on every message.
   </Step>
 </Steps>
 
@@ -86,30 +99,51 @@ After Matrix init completes in the background, the runtime reads two further pie
 1. **UCAN signing mnemonic** — used by `UcanService` to mint downstream-service invocations.
 2. **P-256 encryption key** — used by `SecretsService` to decrypt per-room secrets.
 
-If a key is missing, boot logs a warning naming the CLI command to fix it. Auth-requiring routes return 401 until provisioned; non-authenticated routes (`/health`, `/docs`, any host or plugin `authExcludedRoutes`) stay reachable.
+If a key is missing, boot logs a warning naming the CLI command to fix it. Auth-requiring routes return 401 until provisioned; non-authenticated routes (`/`, `/health`, `/docs`, any host or plugin `authExcludedRoutes`) stay reachable.
 
 ## Per-request user auth
 
-Every chat request carries headers [`AuthHeaderMiddleware`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts) verifies on protected routes.
+Two distinct concerns, two distinct artifacts — [`AuthHeaderMiddleware`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts) verifies both on every protected route:
+
+- **Authentication (who is calling)** = a user-signed UCAN **invocation**. Short-lived, replay-bounded, sent as `Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`. This is the **primary** auth path.
+- **Authorization (what the oracle may do downstream)** = the user→oracle **delegation**, sent as `x-ucan-delegation`. Plugins read it to mint downstream-service invocations on the user's behalf.
+
+<Note>
+A bare `x-ucan-delegation` (no invocation) is still accepted **as a migration fallback** for clients that haven't moved to invocation auth yet. New clients should send both: the invocation to authenticate, the delegation for downstream authorization.
+</Note>
 
 | Header | Required | Purpose |
 | --- | --- | --- |
-| `x-ucan-delegation` | yes | UCAN envelope authorising this user. Missing → 401 `Missing x-ucan-delegation header`. |
-| `x-did` | no | The user's IXO DID (set by SDK; runtime also derives it from the UCAN). |
+| `Authorization: Bearer <invocation>` | yes (primary) | The user-signed UCAN invocation — proves *who* is calling. Only read when `X-Auth-Type: ucan` is also present. |
+| `X-Auth-Type: ucan` | yes (primary) | Selector that tells the middleware to read the bearer token as a UCAN invocation. Without it the bearer is ignored. |
+| `x-ucan-delegation` | fallback / downstream-authz | The user→oracle delegation. Carries the capabilities plugins use to mint downstream invocations. Also accepted as the auth artifact on its own for pre-invocation clients. |
+| `x-did` | no | The user's IXO DID (set by SDK; runtime derives the authenticated DID from the invocation/delegation regardless). Not used for authentication. |
 | `x-matrix-access-token` | no | For clients that already have a Matrix session. |
 | `x-matrix-homeserver` | no | Matrix homeserver for the user. |
 | `x-timezone` | no | Propagates to `rtCtx.user.timezone`. |
 | `x-request-id` | no | Correlation ID for logs and traces. |
 
+When neither an invocation nor a delegation is present, the middleware returns **401** with:
+
+```text
+Missing UCAN authentication: provide Authorization: Bearer <invocation> with X-Auth-Type: ucan, or an x-ucan-delegation header
+```
+
+A malformed or expired invocation returns **401** `Invalid UCAN invocation`.
+
 `AuthHeaderMiddleware`:
 
 <Steps>
-  <Step title="Validates the UCAN delegation">
-    Calls [`createUCANValidator`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/modules/auth/auth-header.middleware.ts) with the oracle's DID as audience. Verifies signature, expiry, and capabilities. Caches the result for 3 minutes (or until the delegation expires, whichever is sooner).
+  <Step title="Validates the invocation (primary)">
+    When `X-Auth-Type: ucan` + `Authorization: Bearer …` are present, [`validateUcanInvocation`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/modules/auth/validate-ucan-invocation.ts) verifies the signature and audience (the oracle's `ORACLE_DID`) and rejects any invocation whose lifetime exceeds `UCAN_AUTH_MAX_TTL_SECONDS` (default 900s). Results are cached by the token's SHA-256 hash with **TTL = the invocation's own expiry**, so reusing the same token until it expires (JWT-style) doesn't re-hit Blocksync. The invocation's signer becomes `req.authData.did`.
   </Step>
 
-  <Step title="Resolves the user's DID">
-    The delegation's invoker becomes `req.authData.did`. Plugin tool handlers read it as `rtCtx.user.did`.
+  <Step title="Falls back to the delegation (migration only)">
+    When no invocation is sent, [`validateUcanDelegation`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/modules/auth/validate-ucan-delegation.ts) authenticates the request from `x-ucan-delegation` instead. Delegation results cache with TTL = the delegation's expiry (or a 3-minute fallback when it declares none).
+  </Step>
+
+  <Step title="Trusts the delegation downstream only when it's the caller's own">
+    A delegation is public and shareable, so the middleware acts on it downstream **only when its issuer DID equals the authenticated DID**. When they differ, the delegation is ignored downstream — `req.authData.ucanDelegation.raw` is set to `''`, and plugins branch on `raw.length === 0`. This stops a client from pairing their own invocation with someone else's delegation to make the oracle act on that person's behalf.
   </Step>
 
   <Step title="Attaches RuntimeUserContext to the request">
@@ -119,7 +153,7 @@ Every chat request carries headers [`AuthHeaderMiddleware`](https://github.com/i
 
 ## Opt routes out of auth
 
-Two mechanisms to expose public routes — host-level and plugin-level. Both merge onto the runtime's built-in exclusion list (`/health`, `/docs`, ...).
+Two mechanisms to expose public routes — host-level and plugin-level. Both merge onto the runtime's built-in exclusion list: `/` (the JSON landing payload), `/health`, `/docs`, and `/docs/(.*)`.
 
 <Steps>
   <Step title="From the host — pass authExcludedRoutes to createOracleApp">
@@ -156,16 +190,33 @@ Any other plugin or host route returns 401 without a UCAN header — exclusion i
 
 ## Mint downstream UCAN invocations
 
-When a plugin calls a downstream service on the user's behalf, it does not reuse the user's UCAN — it mints a fresh invocation signed by the oracle's `SECP_MNEMONIC`, delegating from the user's delegation.
+When a plugin calls a downstream service on the user's behalf, it does not reuse the user's invocation — it mints a fresh one signed by the oracle's `SECP_MNEMONIC`, derived from the user's stored delegation. The minted invocation goes out to the downstream service the same way the user authenticates to *this* oracle: `Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`.
 
 ```ts
 handler: async (args, rtCtx: RuntimeContext) => {
+  // No signing key (mnemonic not yet provisioned) → minting is a no-op.
+  if (!rtCtx.ucan.hasSigningKey()) {
+    return JSON.stringify({ error: 'Oracle signing key not provisioned.' });
+  }
+
+  // Resolve the service URL to its did:web identifier, then mint against it.
+  const serviceDid = await rtCtx.ucan.resolveServiceDid(
+    'https://downstream-service.example',
+  );
+  if (!serviceDid) {
+    return JSON.stringify({ error: 'Could not resolve downstream service DID.' });
+  }
+
   const invocation = await rtCtx.ucan.mintInvocation({
-    did: 'did:web:downstream-service',
-    capability: 'fetch/read',
+    did: serviceDid,
+    capability: 'ixo:downstream',
   });
+
   const resp = await fetch('https://downstream-service.example/data', {
-    headers: { 'x-ucan-delegation': invocation },
+    headers: {
+      Authorization: `Bearer ${invocation}`,
+      'X-Auth-Type': 'ucan',
+    },
   });
   // ...
 }
@@ -175,10 +226,12 @@ The full UCAN helper surface on `rtCtx.ucan`:
 
 | Method | Purpose |
 | --- | --- |
-| `mintInvocation(target, opts?)` | Mint a service-targeted invocation. `opts.skipCache` forces a fresh signature. |
+| `mintInvocation(target, opts?)` | Mint a service-targeted invocation from the user's cached delegation. `target` = `{ did, capability }`; `opts.skipCache` forces a fresh signature. |
 | `requireCapability(resource, action)` | Throws if the user's delegation doesn't include the capability. |
 | `hasCapability(resource, action)` | Returns a boolean — non-throwing variant. |
 | `resolveServiceDid(serviceUrl)` | Resolves a service URL to its `did:web:...` identifier. Returns `null` when the DID document is missing or has no `id`. |
+| `hasSigningKey()` | Returns `true` once the oracle has loaded its Ed25519 signing mnemonic. Gate tool registration on this — without a key, minting is a no-op. |
+| `createInvocationFromDelegation(car, serviceUrl, capability, opts?)` | Mint from a directly-supplied delegation CAR (rather than the per-user cached one). Returns `{ invocation }` or `{ error }`. Used by the editor's `mint_invocation` tool. |
 
 See [`packages/oracle-runtime/src/modules/ucan/`](https://github.com/ixoworld/ixo-oracles-boilerplate/tree/main/packages/oracle-runtime/src/modules/ucan) for the service implementation.
 

--- a/build-an-oracle/develop/observability.mdx
+++ b/build-an-oracle/develop/observability.mdx
@@ -6,7 +6,7 @@ icon: "chart-line"
 
 ## Turn on LangSmith in one block
 
-LangChain auto-wires tracing when these env vars are present in `process.env` — the runtime never reads them, only declares them in the [base env schema](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/config/base-env-schema.ts) so they show up in `qiforge env` output.
+LangChain auto-wires tracing when these env vars are present in `process.env` — the runtime never reads them, only declares them in the [base env schema](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/config/base-env-schema.ts) so they show up in `qiforge-cli env` output.
 
 ```text
 LANGSMITH_TRACING=true
@@ -15,12 +15,16 @@ LANGSMITH_PROJECT=my-oracle
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com   # optional, defaults to LangSmith cloud
 ```
 
-| Env var | Required | Purpose |
+| Env var | Required for tracing | Purpose |
 | --- | --- | --- |
 | `LANGSMITH_TRACING` | yes | Set to `true` to enable tracing. Anything else (or unset) disables it. |
 | `LANGSMITH_API_KEY` | yes | API key from your LangSmith workspace. |
 | `LANGSMITH_PROJECT` | yes | Project name traces land under. |
 | `LANGSMITH_ENDPOINT` | no | Override for self-hosted LangSmith. Defaults to LangSmith cloud. |
+
+<Note>
+All four `LANGSMITH_*` vars are `optional()` in the [base env schema](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/config/base-env-schema.ts) — boot never fails when they're absent. "Required" above means "required for tracing to work," not a boot-time requirement.
+</Note>
 
 No code changes needed. Set the vars and every LLM call, tool invocation, and middleware hook produces a span in the LangSmith UI. Unset them to turn it off.
 
@@ -99,7 +103,7 @@ if (status.excluded.length > 0) {
 }
 ```
 
-Shape of the snapshot — defined in [`packages/oracle-runtime/src/bootstrap/plugin-loader.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/bootstrap/plugin-loader.ts):
+Shape of the snapshot — the `PluginStatusReport` defined in [`packages/oracle-runtime/src/bootstrap/create-oracle-app.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/bootstrap/create-oracle-app.ts):
 
 ```ts
 {
@@ -107,11 +111,14 @@ Shape of the snapshot — defined in [`packages/oracle-runtime/src/bootstrap/plu
   excluded: Array<{
     plugin: string;
     reason: string;                                  // e.g. "auto-detect precondition not met (COMPOSIO_API_KEY)"
-    cause: 'feature_false' | 'auto_detect_missing' | 'cascaded';
   }>;
   softDepGaps: Array<{ plugin: string; missing: string }>;
 }
 ```
+
+<Note>
+The loader tracks an internal `cause` (`feature_false` / `auto_detect_missing` / `cascaded`) for each excluded plugin, but the public `app.plugins.status()` report drops it — `excluded` items are `{ plugin, reason }` only.
+</Note>
 
 ## Use the plugin-scoped logger
 

--- a/build-an-oracle/develop/overview.mdx
+++ b/build-an-oracle/develop/overview.mdx
@@ -10,7 +10,7 @@ The Build track is task-oriented. Every page answers "how do I do X" with a copy
 
 <Steps>
   <Step title="Scaffold an oracle" icon="play">
-    Follow the [Quickstart](/build-an-oracle/quickstart) — `qiforge-cli init`, env, `pnpm dev`, first message. Ten minutes.
+    Follow the [Quickstart](/build-an-oracle/quickstart) — `qiforge-cli new`, env, `pnpm dev`, first message. Ten minutes.
   </Step>
   <Step title="Wire createOracleApp" icon="gear">
     [Create your oracle app](/build-an-oracle/develop/create-oracle-app) — what `main.ts` looks like, what every option does.
@@ -45,7 +45,7 @@ The Build track is task-oriented. Every page answers "how do I do X" with a copy
     Nest agents with their own prompt + tools.
   </Card>
   <Card title="Add a middleware" icon="filter" href="/build-an-oracle/develop/plugin-recipes/add-a-middleware">
-    `beforeModel` / `afterModel` / `onError` hooks.
+    `beforeModel` / `afterModel` / `wrapModelCall` hooks.
   </Card>
   <Card title="Add HTTP endpoints" icon="server" href="/build-an-oracle/develop/plugin-recipes/add-http-endpoints">
     Plugin-owned Nest controllers + auth-excluded routes.

--- a/build-an-oracle/develop/plugin-recipes/add-a-middleware.mdx
+++ b/build-an-oracle/develop/plugin-recipes/add-a-middleware.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Add a middleware"
-description: "Hook into every LLM call via beforeModel, afterModel, and onError using createMiddleware."
+description: "Hook into every LLM call via beforeModel, afterModel, and wrapModelCall using createMiddleware."
 icon: "filter"
 ---
 
@@ -8,7 +8,7 @@ A middleware wraps the agent's LLM call. Return one from `getMiddlewares(ctx)` a
 
 <Steps>
   <Step title="Build the middleware with createMiddleware">
-    Import `createMiddleware` from `langchain`. Set a `name` (appears in error messages) and any of the three hooks.
+    Import `createMiddleware` from `langchain`. Set a `name` (appears in error messages) and any of the six hooks.
 
     ```ts
     import { type AgentMiddleware, type PluginContext } from '@ixo/oracle-runtime';
@@ -34,28 +34,67 @@ A middleware wraps the agent's LLM call. Return one from `getMiddlewares(ctx)` a
   </Step>
 
   <Step title="Pick the right hook">
-    Each hook receives the LangGraph state. Use the one whose timing matches your work.
+    `createMiddleware` accepts exactly six hooks. Pick the one whose timing matches your work — there is no `onError`, no `beforeToolCall`, no `afterToolCall`.
+
+    | Hook | Fires | Use for |
+    | --- | --- | --- |
+    | `beforeAgent` | Once, before the agent loop starts | One-time setup per turn |
+    | `beforeModel` | Before every LLM call | Logging, timers, observation |
+    | `wrapModelCall` | Around every LLM call (you call `handler`) | Error handling, fallbacks, retries |
+    | `wrapToolCall` | Around every tool call (you call `handler`) | Tool-level interception |
+    | `afterModel` | After every LLM call | Logging, emitting events |
+    | `afterAgent` | Once, after the agent loop ends | Teardown, final accounting |
 
     ```ts
     createMiddleware({
       name: 'MyMiddleware',
-      beforeModel: async (state) => {
-        // Loading context, mutating state, blocking unsafe inputs
+      beforeModel: async () => {
+        // Loading context, observation
       },
-      afterModel: async (state) => {
-        // Logging, observation, emitting events
-      },
-      onError: async (error, state) => {
-        // Recovery, metrics, fallback content
+      afterModel: async () => {
+        // Logging, emitting events
       },
     });
     ```
 
-    For state mutations, return a partial state object from the hook — same protocol as LangChain's `AgentMiddleware`.
+    Error handling lives in `wrapModelCall`: wrap the `handler(request)` call in a try/catch and retry with a fallback model. The hook owns the call, so you decide what happens on failure.
+
+    ```ts
+    import { ChatOpenAI } from '@langchain/openai';
+
+    createMiddleware({
+      name: 'ModelFallbackMiddleware',
+      wrapModelCall: async (request, handler) => {
+        try {
+          return await handler(request);
+        } catch (err) {
+          ctx.logger.warn(`primary model failed: ${String(err)} — falling back`);
+          return handler({ ...request, model: new ChatOpenAI({ model: 'gpt-4o-mini' }) });
+        }
+      },
+    });
+    ```
+  </Step>
+
+  <Step title="Return undefined or jumpTo — never a state object">
+    <Warning>
+      The flow-control hooks (`beforeAgent`, `beforeModel`, `afterModel`, `afterAgent`) must return **`undefined`** (pass through) or **`{ jumpTo: 'end' as const }`** (short-circuit the turn). Never return `{ messages: ... }` or any other state channel. (The `wrap*` hooks are different — they return the result of calling `handler`, as in the fallback example above.)
+    </Warning>
+
+    Returning a partial state object from a plugin middleware breaks LangGraph checkpointer thread continuity — the observed symptom is a brand-new thread spawned on every message. Message and state rewrites belong in the transport layer (the messages controller), not in a middleware hook.
+
+    ```ts
+    beforeModel: async (state) => {
+      if (shouldStop(state)) {
+        return { jumpTo: 'end' as const }; // stop the loop early
+      }
+      return undefined; // otherwise pass through
+    },
+    ```
   </Step>
 
   <Step title="Return it from getMiddlewares(ctx)">
-    The runtime appends your middleware after the four always-on framework middleware.
+    The runtime appends your middleware after the framework's built-in middleware (see the list below).
 
     ```ts
     import { OraclePlugin, type AgentMiddleware, type PluginContext } from '@ixo/oracle-runtime';
@@ -87,7 +126,7 @@ A middleware wraps the agent's LLM call. Return one from `getMiddlewares(ctx)` a
 
 ## What to know before shipping
 
-- The four always-on middleware (`tool-validation`, `tool-retry`, `page-context`, `safety-guardrail`) always run first. They are not removable.
+- Four always-on middleware run first and are not removable, in this order: `capability-gate`, `tool-validation`, `tool-repetition-guard`, `tool-retry`. Two more run only when the matching hook is set on `createOracleApp`: `page-context` (when `hooks.getRoomTitle` is provided) and `safety-guardrail` (when `hooks.safetyModel` is provided). Your plugin middleware is appended after all of these.
 - Plugin middleware runs in topological dependency order — encode ordering via `dependsOn` if it matters.
 - Middleware fires per LLM turn, not per individual tool invocation. Wrap the tool handler directly for per-tool behaviour.
 - Closure-scoped timers interleave across concurrent model calls. For accurate timing, push start times onto a per-call ID.

--- a/build-an-oracle/develop/plugin-recipes/add-a-sub-agent.mdx
+++ b/build-an-oracle/develop/plugin-recipes/add-a-sub-agent.mdx
@@ -99,13 +99,15 @@ A sub-agent is a `PluginSubAgent` the runtime auto-wraps as a tool (e.g. `weathe
 
     ```ts
     override getRequestSubAgents(rtCtx: RuntimeContext): PluginSubAgent[] {
-      const browserTools = rtCtx.history.state.browserTools;
-      if (!browserTools || browserTools.length === 0) return [];
-      return [buildPortalSubAgent(browserTools)];
+      // ReadonlyState's index signature types arbitrary keys as `unknown`,
+      // so narrow before reading `.length`.
+      const agActions = rtCtx.history.state.agActions;
+      if (!Array.isArray(agActions) || agActions.length === 0) return [];
+      return [buildActionAwareSubAgent(agActions)];
     }
     ```
 
-    Boot-time `getSubAgents` and request-time `getRequestSubAgents` outputs merge.
+    `state.agActions` (live AG-UI actions) is the canonical request-time field — reading it through `rtCtx.history.state` returns `unknown`, so validate with `Array.isArray(...)` before use. Boot-time `getSubAgents` and request-time `getRequestSubAgents` outputs merge.
   </Step>
 </Steps>
 

--- a/build-an-oracle/develop/plugin-recipes/add-http-endpoints.mdx
+++ b/build-an-oracle/develop/plugin-recipes/add-http-endpoints.mdx
@@ -88,7 +88,7 @@ Use `getNestModules` for webhooks, public probes, OAuth callbacks, or long-lived
     Boot the oracle with `pnpm dev`, then curl the route without an auth header.
 
     ```sh
-    curl 'http://localhost:5678/weather/now?city=Berlin'
+    curl 'http://localhost:3000/weather/now?city=Berlin'
     ```
 
     Other routes still 401 — the exclusion list only opts these specific paths out.

--- a/build-an-oracle/develop/plugin-recipes/declare-dependencies.mdx
+++ b/build-an-oracle/develop/plugin-recipes/declare-dependencies.mdx
@@ -19,7 +19,7 @@ A plugin references other plugins by `name`. `dependsOn` is hard (boot fails on 
     }
     ```
 
-    Missing dep: `[boot-error] Plugin 'skills' depends on 'sandbox', which is not loaded. Add 'sandbox' to features, or remove 'skills'.` Canonical source: [oracle-plugin.ts](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugin-api/oracle-plugin.ts).
+    Missing dep (grep your boot logs for the `boot.plugin.dep_missing` code): `[boot-error] boot.plugin.dep_missing: plugin 'skills' requires 'sandbox', which is not loaded. Add 'sandbox' to features, or remove 'skills'.` Canonical source: [oracle-plugin.ts](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugin-api/oracle-plugin.ts).
   </Step>
 
   <Step title="Declare soft dependencies via softDependsOn">

--- a/build-an-oracle/develop/plugin-recipes/set-visibility.mdx
+++ b/build-an-oracle/develop/plugin-recipes/set-visibility.mdx
@@ -21,7 +21,11 @@ icon: "eye"
     };
     ```
 
-    Three tiers: `'always'` (bound to agent at boot, listed in Tier-1 prompt), `'on-demand'` (default — discoverable via `list_capabilities`, loaded via `load_capability`), `'silent'` (invisible to agent; runs middleware-only). Canonical source: [weather.plugin.ts](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/apps/qiforge-example/src/plugins/weather/weather.plugin.ts).
+    Three tiers: `'always'` (bound to the agent at boot, listed in the Tier-1 prompt), `'on-demand'` (default — discoverable via `list_capabilities`, loaded via `load_capability`), `'silent'` (not advertised — see the warning below). Canonical source: [weather.plugin.ts](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/apps/qiforge-example/src/plugins/weather/weather.plugin.ts).
+
+    <Warning>
+      `'silent'` controls **advertising, not access** — it is not a security boundary. A silent plugin is left out of the Tier-1 capability block, excluded from `list_capabilities` (by default), and rejected by `load_capability`. But if a silent plugin returns tools, the capability gate passes them straight through to the model, exactly like `'always'`-tier tools. Use `'silent'` for transport/middleware/Nest-module plugins (e.g. Slack transport, credits/billing) that have nothing to advertise to the agent — never to "hide" a sensitive capability.
+    </Warning>
   </Step>
 
   <Step title="Override visibility per tool">
@@ -55,14 +59,14 @@ icon: "eye"
 
     ```mermaid
     graph TD
-        A["Does the LLM need to<br/>see this plugin as tools?"]
-        A -->|No| Silent[silent]
-        A -->|Yes| B["Will the LLM use this<br/>plugin on most turns?"]
+        A["Does this plugin expose<br/>agent-callable tools?"]
+        A -->|No — middleware / transport only| Silent[silent]
+        A -->|Yes| B["Should the agent use it<br/>on most turns?"]
         B -->|Yes| Always[always]
-        B -->|No| OnDemand[on-demand]
+        B -->|No — discover on demand| OnDemand[on-demand]
     ```
 
-    Promoting to `'always'` costs ~80 tokens per plugin in the Tier-1 prompt plus the tool schemas on every turn. Demoting to `'silent'` removes the plugin from the agent's view entirely.
+    Promoting to `'always'` costs ~80 tokens per plugin in the Tier-1 prompt plus the tool schemas on every turn. `'silent'` simply stops advertising the plugin to the agent — it does not hide or disable any tools the plugin returns.
   </Step>
 </Steps>
 
@@ -71,7 +75,7 @@ icon: "eye"
 - Default is `'on-demand'`. A plugin without an explicit `manifest.visibility` is treated as on-demand.
 - `'on-demand'` plugins live in a per-thread `loadedPlugins` set. The set is monotonic — loading is forever for that thread; a new thread resets it.
 - Per-tool overrides let you ship a mixed plugin (one `'always'` tool + several `'on-demand'` tools) without splitting it.
-- `'silent'` plugins still run their middleware and Nest modules. Use this for instrumentation, rate limiting, billing.
+- `'silent'` plugins still run their middleware and Nest modules, and any tools they return stay callable by the agent — they're just never advertised. Use it for instrumentation, rate limiting, billing, and transports. It is not a way to hide a capability for security.
 - A fork with 50 `'on-demand'` plugins can usually keep 3–5 loaded per thread — the budget stays bounded as the catalog grows.
 
 ## Where to read next

--- a/build-an-oracle/develop/test-your-oracle.mdx
+++ b/build-an-oracle/develop/test-your-oracle.mdx
@@ -118,6 +118,8 @@ Every integration test file lists the env it needs and throws at module load if 
 
 ## Unit test — createTestRuntime
 
+`createTestRuntime` returns a `TestRuntime` directly (no `{ runtime }` wrapper). Drive it through that object's methods — `listTools`, `invokeTool`, `invokeMiddleware`, `invokeSubAgent`, `listCapabilities`, `getManifest`, `assertNoCollisions`, `assertManifestValid`.
+
 ```ts
 import { describe, expect, it } from 'vitest';
 import { createTestRuntime } from '@ixo/oracle-runtime/testing';
@@ -125,16 +127,26 @@ import { WeatherPlugin } from '../src/plugins/weather/index.js';
 
 describe('WeatherPlugin', () => {
   it('registers get_current_weather at boot', async () => {
-    const { runtime } = await createTestRuntime({
+    const runtime = await createTestRuntime({
       plugins: [new WeatherPlugin()],
-      env: { WEATHER_DEFAULT_UNITS: 'celsius' },
+      config: { WEATHER_DEFAULT_UNITS: 'celsius' },
     });
-    expect(runtime.toolRegistry.toolNames()).toContain('get_current_weather');
+    expect(runtime.listTools().map((t) => t.name)).toContain('get_current_weather');
+  });
+
+  it('has valid manifests and no registry collisions', async () => {
+    const runtime = await createTestRuntime({ plugins: [new WeatherPlugin()] });
+    expect(() => runtime.assertManifestValid()).not.toThrow();
+    expect(() => runtime.assertNoCollisions()).not.toThrow();
   });
 });
 ```
 
-`createTestRuntime` resolves plugins, populates registries, and builds a `RuntimeContext` you can hand straight to tool handlers — but does not boot Nest, talk to Matrix, or call the LLM. Use for fast, focused tests.
+`createTestRuntime` resolves plugins, populates the six registries, and builds a `RuntimeContext` it hands to tool handlers — but does not boot Nest, talk to Matrix, or call the LLM (every ambient service is a mock). Pass plugin env through `config`. Use for fast, focused tests: tool registration, manifest validity, middleware hooks, and sub-agent prompts in isolation.
+
+<Note>
+`createTestRuntime` options take `config` (plugin env, read as `ctx.config`) — not `env`. Its `mocks.fetch` is exposed for handlers that read it explicitly; it is **not** auto-installed onto `globalThis.fetch`. To stub a plugin's upstream HTTP calls deterministically, use the Tier A `createIntegrationRuntime`, whose `fetch` option does replace `globalThis.fetch`. The full `TestRuntime` surface lives in [`create-test-runtime.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/testing/create-test-runtime.ts).
+</Note>
 
 ## Tier A integration — direct invoke
 
@@ -171,6 +183,12 @@ describe('Tier A — direct invoke', () => {
 
 Tier A boots the runtime registries against your plugin list but skips the agent loop entirely. Use it to verify env wiring, upstream-API contracts, and config threading.
 
+`createIntegrationRuntime` accepts more than `plugins` + `user`: `config` (plugin env, defaults to `process.env`), `features`, `delegation`, `capabilities`, `session`, `state`, `identity`, `fetch` (stub upstreams), and `ucan`.
+
+<Warning>
+The default `ucan` stub **throws** on `mintInvocation` / `createInvocationFromDelegation`. If the plugin under test mints downstream invocations (memory, sandbox, skills, composio, …), pass a real adapter — boot an oracle with `createIntegrationOracle()` and hand its `bootedOracle.app.ambient.ucan` through as `ucan`, after seeding the user's delegation into that oracle's `UcanService` cache.
+</Warning>
+
 ## Tier B integration — full agent loop
 
 ```ts
@@ -178,6 +196,7 @@ import {
   ChatClient,
   allCaps,
   createIntegrationOracle,
+  mintAuthInvocation,
   mintUserDelegation,
   waitForMatrixLoaded,
   type IntegrationOracle,
@@ -200,13 +219,20 @@ describe('Tier B — agent loop', () => {
     });
     await waitForMatrixLoaded(oracle, 90_000);
 
+    // Primary auth: a user-signed invocation (Authorization: Bearer +
+    // X-Auth-Type: ucan). Downstream authorization: the delegation.
+    const invocation = await mintAuthInvocation({
+      userMnemonic: process.env.TEST_USER_MNEMONIC!,
+      oracleDid: process.env.ORACLE_DID!,
+      userDid: process.env.TEST_USER_DID,
+    });
     const delegation = await mintUserDelegation({
       userMnemonic: process.env.TEST_USER_MNEMONIC!,
       oracleDid: process.env.ORACLE_DID!,
       userDid: process.env.TEST_USER_DID,
       capabilities: allCaps,
     });
-    client = new ChatClient(oracle.baseUrl, { delegation });
+    client = new ChatClient(oracle.baseUrl, { invocation, delegation });
   }, 180_000);
 
   afterAll(async () => {
@@ -224,6 +250,10 @@ describe('Tier B — agent loop', () => {
   });
 });
 ```
+
+<Note>
+`mintAuthInvocation` (sent as `Authorization: Bearer` + `X-Auth-Type: ucan`) is the **primary** auth artifact the runtime expects; `mintUserDelegation` (sent as `x-ucan-delegation`) carries the capabilities plugins use for downstream authorization. `ChatClient` sends both when supplied — that's the production path. A delegation-only `new ChatClient(url, { delegation })` still authenticates via the migration fallback, which is why older tests pass without an invocation.
+</Note>
 
 Full reference, including multi-turn scenarios: [`weather.int.test.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/apps/qiforge-example/test/integration/weather.int.test.ts). Cross-plugin chains: [`agent-scenarios.int.test.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/apps/qiforge-example/test/integration/agent-scenarios.int.test.ts). Boot smoke: [`boot.int.test.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/apps/qiforge-example/test/integration/boot.int.test.ts).
 
@@ -244,6 +274,10 @@ Full reference, including multi-turn scenarios: [`weather.int.test.ts`](https://
 
   <Accordion title="Assert structurally on streamed events" icon="list-check">
     Tier B uses a real model — response wording drifts. Collect `tool_call` events from the stream and assert which tools fired with which args, not on text output.
+  </Accordion>
+
+  <Accordion title="createIntegrationOracle swaps in cheaper test models" icon="dollar-sign">
+    `createIntegrationOracle` installs a default `resolveModel` hook that overrides the `main` and `subagent` roles with cheaper test models; every other role falls through to the production resolver. Pass your own `hooks` to override — caller hooks merge on top per key, so a caller-supplied `resolveModel` wins.
   </Accordion>
 </AccordionGroup>
 

--- a/build-an-oracle/develop/write-a-plugin.mdx
+++ b/build-an-oracle/develop/write-a-plugin.mdx
@@ -36,10 +36,83 @@ export class WeatherPlugin extends OraclePlugin {
 
 Each step below builds one of those lines.
 
+## Two ways to author a plugin
+
+Every hook in this guide works identically whether you subclass `OraclePlugin` or use the `defineOraclePlugin` helper. Pick whichever you prefer — the runtime treats the resulting object exactly the same way.
+
+<Tabs>
+  <Tab title="Class (extends OraclePlugin)">
+    Subclass and `override` each hook. Per-session state lives on `private` fields. Register with `new WeatherPlugin()`.
+
+    ```ts
+    export class WeatherPlugin extends OraclePlugin {
+      readonly name = 'weather';
+      readonly version = '0.1.0';
+      readonly manifest = manifest;
+      override readonly configSchema = configSchema;
+
+      private readonly lastBySession: LastQueryStore = new Map();
+
+      override autoDetect(): boolean { return true; }
+      override getTools(ctx: PluginContext): PluginTool[] {
+        return [buildCurrentWeatherTool(this.units(ctx.config), this.lastBySession)];
+      }
+      // …every other hook as an override
+    }
+    ```
+
+    ```ts
+    plugins: [new WeatherPlugin()],
+    ```
+  </Tab>
+  <Tab title="POJO (defineOraclePlugin)">
+    Pass a plain object — `name`, `version`, and `manifest` are required; every hook is optional. Per-session state lives in a module-scoped closure. `defineOraclePlugin` returns a ready `OraclePlugin`, so register it **without** `new`.
+
+    ```ts
+    import {
+      defineOraclePlugin,
+      type PluginContext,
+      type RuntimeContext,
+    } from '@ixo/oracle-runtime';
+    import { RequestMethod } from '@nestjs/common';
+
+    const lastBySession: LastQueryStore = new Map();
+    const units = (config: unknown) => configSchema.parse(config).WEATHER_DEFAULT_UNITS;
+
+    export const weatherPlugin = defineOraclePlugin({
+      name: 'weather',
+      version: '0.1.0',
+      manifest,
+      configSchema,
+      autoDetectHint: 'always on (set WEATHER_DEFAULT_UNITS to celsius|fahrenheit)',
+      autoDetect: () => true,
+      getTools: (ctx) => [buildCurrentWeatherTool(units(ctx.config), lastBySession)],
+      getRequestTools: (rtCtx) => [buildForecastTool(units(rtCtx.config), lastBySession)],
+      getSubAgents: (ctx) => [buildWeatherPlannerSubAgent(units(ctx.config), lastBySession)],
+      getMiddlewares: (ctx) => [buildWeatherMiddleware(ctx)],
+      getNestModules: (ctx) => [WeatherHttpModule.register(units(ctx.config))],
+      getAuthExcludedRoutes: () => [{ path: 'weather/now', method: RequestMethod.GET }],
+      getSharedState: () => ({
+        lastWeatherQuery: (_state, runCtx: RuntimeContext) =>
+          lastBySession.get(runCtx.session.id),
+      }),
+    });
+    ```
+
+    ```ts
+    plugins: [weatherPlugin],   // already an instance — no `new`
+    ```
+
+    `defineOraclePlugin` throws a `TypeError` at authoring time if `name`, `version`, or `manifest` is missing. Source: [`define-plugin.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugin-api/define-plugin.ts).
+  </Tab>
+</Tabs>
+
+The rest of this guide uses the class form (matching the reference oracle), but every snippet maps one-to-one onto a `defineOraclePlugin` field.
+
 ## Prerequisites
 
 - A working `main.ts` calling `createOracleApp` — see [Create your oracle](/build-an-oracle/develop/create-oracle-app).
-- The oracle scaffolded by the CLI (`qiforge init`) — see the [CLI reference](/build-an-oracle/reference/cli).
+- The oracle scaffolded by the CLI (`qiforge-cli new`) — see the [CLI reference](/build-an-oracle/reference/cli).
 - Files live under `src/plugins/weather/` — same layout as the reference [apps/qiforge-example/src/plugins/weather/](https://github.com/ixoworld/ixo-oracles-boilerplate/tree/main/apps/qiforge-example/src/plugins/weather).
 
 ## Step-by-step
@@ -283,7 +356,7 @@ Each step below builds one of those lines.
     }
     ```
 
-    Plugin middleware runs after the framework's always-on middleware (tool validation, retry, page context, safety guardrail), in topological dependency order across plugins.
+    Plugin middleware runs after the framework's always-on middleware (`capability-gate`, `tool-validation`, `tool-repetition-guard`, `tool-retry`) — plus the conditional `page-context` / `safety-guardrail` when their hooks are configured — in topological dependency order across plugins. A plugin middleware hook must return `undefined` or `{ jumpTo: 'end' as const }`, never a partial state object — see [Add a middleware](/build-an-oracle/develop/plugin-recipes/add-a-middleware).
   </Step>
 
   <Step title="Add an HTTP route with getNestModules + getAuthExcludedRoutes">
@@ -375,7 +448,7 @@ Each step below builds one of those lines.
 
     | Hook | How to verify |
     | --- | --- |
-    | `getNestModules` + `getAuthExcludedRoutes` | `curl 'http://localhost:5678/weather/now?city=Berlin'` returns JSON without a UCAN header. |
+    | `getNestModules` + `getAuthExcludedRoutes` | `curl 'http://localhost:3000/weather/now?city=Berlin'` returns JSON without a UCAN header. |
     | `manifest.visibility: 'on-demand'` | Chat `what's the weather in Berlin?` — the agent calls `list_capabilities` and/or `load_capability` before any weather tool. |
     | `getTools` | After weather is loaded, chat `what's the temperature in Tokyo?` — `get_current_weather` fires. |
     | `getRequestTools` | Chat `forecast for São Paulo this week` with an `x-timezone` header — `get_weather_forecast` fires; handler reads `rtCtx.user.timezone`. |

--- a/build-an-oracle/for-ai-agents.mdx
+++ b/build-an-oracle/for-ai-agents.mdx
@@ -9,7 +9,7 @@ This page is for AI tools (Cursor, Claude Code, Codex, …) scaffolding a QiForg
 If you are an AI agent: read top-to-bottom once. Every signature you need is inlined. Source paths cite the canonical files on the QiForge runtime ([`packages/oracle-runtime`](https://github.com/ixoworld/ixo-oracles-boilerplate/tree/main/packages/oracle-runtime)) and the reference oracle ([`apps/qiforge-example`](https://github.com/ixoworld/ixo-oracles-boilerplate/tree/main/apps/qiforge-example)).
 
 <Note>
-**If you are working inside a scaffolded oracle project** (one created with `qiforge-cli --init` or `qiforge-cli new`), there is already a Claude Code skill at `.claude/skills/qiforge-oracle/SKILL.md` with project-local guidance: adding plugins, adding tools, wiring env, writing tests with `createTestRuntime`. Load it first — it carries denser, scenario-specific references than this page.
+**If you are working inside a scaffolded oracle project** (one created with `qiforge-cli new`), there is already a Claude Code skill at `.claude/skills/qiforge-oracle/SKILL.md` with project-local guidance: adding plugins, adding tools, wiring env, writing tests with `createTestRuntime`. Load it first — it carries denser, scenario-specific references than this page.
 </Note>
 
 ## TL;DR — what you produce
@@ -65,14 +65,19 @@ interface OracleConfig {
   name: string;
   org?: string;
   description?: string;
-  prompt?: { opening?: string; communicationStyle?: string; capabilities?: string };
+  prompt?: {
+    opening?: string;            // full replacement of the identity preamble
+    communicationStyle?: string; // appended to operating principles (tone/voice)
+    capabilities?: string;       // author elevator pitch above the capability list
+    customInstructions?: string; // verbatim `## Custom Instructions` block
+  };
 }
 
 interface AuthExcludedRoute { path: string; method?: RequestMethod }
 
 interface MainAgentHooks {
   checkpointerForUser?: (userDid: string) => Promise<BaseCheckpointSaver>;
-  resolveModel?: (role: ModelRole, params?: ChatOpenAIFields) => ChatModel;
+  resolveModel?: (role: ModelRole, params?: ChatOpenAIFields) => BaseChatModel;
   getRoomTitle?: (roomId: string) => Promise<string | undefined>;
   safetyModel?: BaseChatModel;
   validationSkipToolNames?: string[];
@@ -170,10 +175,12 @@ interface PluginSubAgent {
 | Visibility | Bound at boot? | In Tier-1 prompt? | Discoverable via `list_capabilities`? |
 | --- | --- | --- | --- |
 | `always` | yes | yes | yes |
-| `on-demand` (default) | no — until `load_capability(name)` | no | yes |
-| `silent` | yes, but agent doesn't see them | no | no |
+| `on-demand` (default) | no — until `load_capability({ names })` | no | yes |
+| `silent` | yes | no | no |
 
-## Bundled plugins (14)
+`silent` means *not advertised* — the tools are still bound and the agent can call them; they're just kept out of the Tier-1 prompt and `list_capabilities`. It is not a security boundary.
+
+## Bundled plugins (15)
 
 From [`packages/oracle-runtime/src/plugins/index.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugins/index.ts):
 
@@ -189,10 +196,11 @@ From [`packages/oracle-runtime/src/plugins/index.ts`](https://github.com/ixoworl
 | `editor` | on-demand | on (needs Matrix) | — |
 | `agui` | on-demand | on | — |
 | `slack` | silent | auto-detect | `SLACK_BOT_OAUTH_TOKEN` |
-| `tasks` | stub | auto-detect (stub) | `REDIS_URL` |
+| `tasks` | on-demand | auto-detect | `REDIS_URL` |
 | `credits` | silent | on unless `DISABLE_CREDITS=true` | — |
-| `calls` | stub | on (stub) | — |
+| `calls` | silent | on (placeholder stub — no tools) | — |
 | `user-preferences` | always | on | — |
+| `matrix-group-chats` | on-demand | on (opt out via `features`) | — (optional `CHANNEL_MEMORY_*`) |
 
 Toggle via `features` in `createOracleApp`: `true` forces on, `false` forces off, `'auto'` runs `autoDetect`.
 
@@ -202,22 +210,42 @@ Per-plugin reference pages: [`/build-an-oracle/reference/bundled-plugins/overvie
 
 From [`packages/oracle-runtime/src/config/base-env-schema.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/config/base-env-schema.ts):
 
+These are the exact names the runtime validates — set them character-for-character or the boot-time Zod check fails.
+
 | Var | Required | Description |
 | --- | --- | --- |
-| `ORACLE_ENTITY_DID` | yes | The oracle's IXO entity DID |
-| `ORACLE_MNEMONIC` | yes | Wallet mnemonic for chain signing |
-| `ORACLE_MATRIX_USER_ID` | yes | Matrix user ID the bot logs in as |
-| `ORACLE_MATRIX_PASSWORD` | yes | Matrix bot password |
-| `ORACLE_MATRIX_HOMESERVER_URL` | yes | Matrix homeserver URL |
-| `IXO_NETWORK_RPC_URL` | yes | IXO chain RPC endpoint |
-| `OPENAI_API_KEY` *or* `ANTHROPIC_API_KEY` | yes | At least one LLM provider key |
-| `LANGSMITH_API_KEY` | optional | Enables LangSmith tracing |
-| `LANGSMITH_TRACING` | optional | `true` to enable |
-| `LANGSMITH_PROJECT` | optional | LangSmith project name |
-| `CORS_ORIGIN` | optional | Wildcard `*` is default |
-| `PORT` | optional | HTTP port; defaults to 3000 |
+| `ORACLE_NAME` | yes | Oracle display name. |
+| `NETWORK` | yes | `mainnet` \| `testnet` \| `devnet`. |
+| `ORACLE_DID` | yes | The oracle's own DID (`did:ixo:ixo1...`); the signer identity for downstream invocations. |
+| `ORACLE_ENTITY_DID` | yes | The oracle's on-chain entity DID (`did:ixo:entity:...`). |
+| `SECP_MNEMONIC` | yes | Wallet mnemonic used to sign UCAN invocations to downstream services. |
+| `RPC_URL` | yes | IXO chain RPC endpoint. |
+| `BLOCKSYNC_GRAPHQL_URL` | yes | Blocksync GraphQL endpoint (UCAN validation reads it). |
+| `MATRIX_BASE_URL` | yes | Matrix homeserver URL. |
+| `MATRIX_RECOVERY_PHRASE` | yes | Recovery phrase for the oracle's Matrix encryption. |
+| `MATRIX_ORACLE_ADMIN_USER_ID` | yes | Matrix user ID the bot logs in as. |
+| `MATRIX_ORACLE_ADMIN_PASSWORD` | yes | Matrix bot password. |
+| `MATRIX_ORACLE_ADMIN_ACCESS_TOKEN` | yes | Matrix bot access token. |
+| `MATRIX_ACCOUNT_ROOM_ID` | yes | Oracle's Matrix account room (holds signing key + secrets). |
+| `MATRIX_VALUE_PIN` | yes | PIN for the oracle's Matrix value store / vault. |
+| `SQLITE_DATABASE_PATH` | yes | Path for the per-user SQLite checkpointer DB. |
+| `LLM_PROVIDER` | optional | `openrouter` (default) \| `nebius`. Selects the per-role model map. |
+| `OPEN_ROUTER_API_KEY` | conditional | Required when `LLM_PROVIDER=openrouter` (the default). |
+| `NEBIUS_API_KEY` | conditional | Required when `LLM_PROVIDER=nebius`. |
+| `OPENAI_API_KEY` | optional | Only if a plugin needs OpenAI directly. Not required for the agent. |
+| `MATRIX_STORE_PATH` | optional | Matrix store dir. Defaults to `./matrix-storage`. |
+| `UCAN_AUTH_MAX_TTL_SECONDS` | optional | Max accepted lifetime of a user auth invocation. Default `900`. |
+| `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS` | optional | Min gap between Matrix re-auth nudges. Default `21600`. |
+| `ORACLE_SECRETS` | optional | Operator secrets as `KEY=val,KEY2=val2`, surfaced as `x-os-*` headers. |
+| `CORS_ORIGIN` | optional | Allowed origins. Wildcard `*` is the default. |
+| `PORT` | optional | HTTP port. Defaults to `3000`. |
+| `NODE_ENV` | optional | `development` (default) \| `production` \| `test`. |
+| `LANGSMITH_TRACING` | optional | `true` to enable LangSmith tracing. |
+| `LANGSMITH_API_KEY` | optional | LangSmith API key. |
+| `LANGSMITH_PROJECT` | optional | LangSmith project name. |
+| `LANGSMITH_ENDPOINT` | optional | LangSmith endpoint override. |
 
-Plugin-specific env vars merge in via each plugin's `configSchema`.
+There is no `ANTHROPIC_API_KEY` — the agent's model id is fixed per role in the provider model map; switch the provider with `LLM_PROVIDER` + its key, or override the main model via the `resolveModel` hook. Plugin-specific env vars (`MEMORY_MCP_URL`, `FIRECRAWL_MCP_URL`, `SANDBOX_MCP_URL`, `COMPOSIO_API_KEY`, `SLACK_BOT_OAUTH_TOKEN`, `REDIS_URL`, …) merge in via each plugin's `configSchema`.
 
 ## Copy-pasteable plugin template
 

--- a/build-an-oracle/index.mdx
+++ b/build-an-oracle/index.mdx
@@ -30,13 +30,13 @@ That's a working oracle. One call to [`createOracleApp`](/build-an-oracle/develo
     HTTP + WebSocket, request validation, OpenAPI at `/docs`, CORS, throttling, graceful shutdown — already configured.
   </Card>
   <Card title="UCAN-based identity and auth" icon="shield-halved">
-    Every request validates an `x-ucan-delegation` header. The oracle has an IXO entity DID; users sign capabilities they delegate to it.
+    Every request is authenticated by a user-signed UCAN invocation (`Authorization: Bearer …` + `X-Auth-Type: ucan`). The oracle has an IXO entity DID; users delegate scoped capabilities it can act on downstream.
   </Card>
   <Card title="Encrypted per-user storage" icon="lock">
     Each user gets a Matrix room; conversation history + agent checkpoints are E2E-encrypted and synced automatically.
   </Card>
   <Card title="A LangGraph agent" icon="diagram-project">
-    Per-request agent build, dynamic tool loading via meta-tools, four always-on middleware (tool validation, retry, page context, safety guardrail).
+    Per-request agent build, dynamic tool loading via meta-tools, four always-on middleware (capability gating, tool validation, repetition guard, retry).
   </Card>
   <Card title="15 bundled plugins" icon="boxes-stacked">
     `memory`, `skills`, `sandbox`, `portal`, `firecrawl`, `composio`, `editor`, `agui`, `slack`, `credits`, `user-preferences`, and more — toggle them via the `features` map.
@@ -75,7 +75,7 @@ You ship the green box on top. The framework handles the rest.
     Every option, every env var, every bundled plugin in a flat table.
   </Card>
   <Card title="CLI" icon="terminal" href="/build-an-oracle/reference/cli">
-    `qiforge-cli` commands — init, dev, build, plugin scaffolds, inspect.
+    `qiforge-cli` commands — `new`, `plugin new`, `create-entity`, `--chat`.
   </Card>
 </CardGroup>
 

--- a/build-an-oracle/quickstart.mdx
+++ b/build-an-oracle/quickstart.mdx
@@ -12,7 +12,7 @@ Oracle: (calls list_capabilities → load_capability(weather) → get_current_we
         Berlin is currently 14°C with light rain.
 ```
 
-A live oracle on `localhost:5678` with:
+A live oracle on `localhost:3000` with:
 
 - The 15 bundled plugins resolved at boot.
 - A custom Weather plugin loading on demand.
@@ -29,9 +29,9 @@ A live oracle on `localhost:5678` with:
 ## Step 1 — install the CLI
 
 ```sh
-pnpm add -g qiforge-cli
-pnpm approve-builds -g           # approve protobufjs when prompted
-qiforge-cli --help
+pnpm add -g qiforge-cli           # npm package name
+pnpm approve-builds -g            # approve protobufjs when prompted
+qiforge-cli --help                # the installed binary is `qiforge-cli`
 ```
 
 If it prints the help text, the CLI is ready.
@@ -49,6 +49,10 @@ The CLI walks through:
 3. **Oracle profile** — name, description, price, model. Defaults are fine.
 4. **Entity creation** — the CLI writes a transaction to register your oracle's entity DID on chain. Confirm when prompted (SignX needs the mobile app; offline signs locally).
 5. **Matrix bot** — provisioned automatically.
+
+<Note>
+Entity creation registers the oracle's API URL as `http://localhost:4000` by default, but the runtime boots on `PORT=3000`. To make your oracle reachable at its registered URL, either set `PORT=4000` in `.env` to match, or change the registered URL later with `qiforge-cli update-oracle-api-url`.
+</Note>
 
 The result is a plugin-runtime-shaped project:
 
@@ -86,7 +90,7 @@ Then follow Step 3 onward against `apps/qiforge-example/`.
 
 ## Step 3 — fill in `.env`
 
-Open `apps/qiforge-example/.env` (or `apps/app/.env` if you used `--init`). The CLI populated identity vars; you need to add the LLM key and any plugin vars:
+Open your project's `.env` (`my-oracle/.env` from `qiforge-cli new`, or `apps/qiforge-example/.env` if you cloned the boilerplate). The CLI populated identity vars; you need to add the LLM key and any plugin vars:
 
 ```diff
 - OPEN_ROUTER_API_KEY=
@@ -122,7 +126,7 @@ You should see something like:
 [Nest] OraclePlugin {user-preferences} loaded (always)
 [Nest] OraclePlugin {weather} loaded (on-demand)
 [boot] excluded plugins: composio (COMPOSIO_API_KEY), slack (SLACK_BOT_OAUTH_TOKEN), tasks (REDIS_URL)
-Oracle 'QiForge Example Oracle' (runtime v0.X.Y) listening on :5678
+Oracle 'QiForge Example Oracle' (runtime v0.X.Y) listening on :3000
 [plugin] matrix pending → loaded
 ```
 
@@ -133,7 +137,7 @@ The excluded plugins are normal — they need env vars you didn't set. To enable
 The Weather plugin exposes `GET /weather/now`. It's marked auth-excluded via `getAuthExcludedRoutes()`, so no UCAN header needed:
 
 ```sh
-curl 'http://localhost:5678/weather/now?city=Berlin'
+curl 'http://localhost:3000/weather/now?city=Berlin'
 ```
 
 You should get back JSON:
@@ -157,7 +161,7 @@ This proves: the plugin loaded, its Nest module mounted, the auth exclusion work
 For interactive chat, use the CLI's streaming TUI:
 
 ```sh
-qiforge-cli chat
+qiforge-cli --chat
 ```
 
 Then type:
@@ -169,7 +173,7 @@ what's the weather in Berlin?
 The agent walks this path:
 
 1. **`list_capabilities`** — sees `weather` is `on-demand`, not loaded yet.
-2. **`load_capability({ name: 'weather' })`** — gets the manifest back with `whenToUse` and the tool list. `loadedPlugins` state field now contains `'weather'`.
+2. **`load_capability({ names: ['weather'] })`** — gets the manifest back with `whenToUse` and the tool list. `loadedPlugins` state field now contains `'weather'`.
 3. **`get_current_weather({ city: 'Berlin' })`** — the actual tool fires.
 4. **Final response** — natural-language summary of the result.
 

--- a/build-an-oracle/reference/api-endpoints.mdx
+++ b/build-an-oracle/reference/api-endpoints.mdx
@@ -12,18 +12,26 @@ The Swagger UI at `/docs` is generated from the running app's controllers — op
 
 ## Authentication
 
-Every protected route requires these headers:
+Protected routes authenticate with a user-signed UCAN **invocation**, plus an optional delegation for downstream authorization. This is the same model the [Identity and auth](/build-an-oracle/develop/identity-and-auth) guide describes.
 
 | Header | Required | Notes |
 | --- | --- | --- |
-| `x-ucan-delegation` | Yes | UCAN envelope authorising the request. |
-| `x-did` | Yes | The user's IXO DID. |
-| `x-matrix-access-token` | Optional | Matrix session token (used by Portal/Slack). |
-| `x-matrix-homeserver` | Optional | Matrix homeserver URL. |
-| `x-timezone` | Optional | Propagates to `rtCtx.user.timezone`. |
-| `x-request-id` | Optional | Correlation ID; echoed back as `X-Request-Id`. |
+| `Authorization: Bearer <invocation>` | Yes (primary) | The user-signed UCAN invocation — proves *who* is calling. Only read when `X-Auth-Type: ucan` is also present. |
+| `X-Auth-Type: ucan` | Yes (primary) | Selector telling the middleware to read the bearer as a UCAN invocation. Without it the bearer is ignored. |
+| `x-ucan-delegation` | Fallback / downstream-authz | The user→oracle delegation. Carries the capabilities plugins use to mint downstream invocations. Also accepted as the auth artifact on its own for clients that haven't migrated to invocation auth. |
+| `x-did` | No | The user's IXO DID (informational). The runtime derives the authenticated DID from the invocation/delegation — **`x-did` is not used for authentication.** |
+| `x-matrix-access-token` | No | Matrix session token (used by Portal/Slack). |
+| `x-matrix-homeserver` | No | Matrix homeserver URL. |
+| `x-timezone` | No | Propagates to `rtCtx.user.timezone`. |
+| `x-request-id` | No | Correlation ID; echoed back as `X-Request-Id`. |
 
-Public routes ignore auth headers and don't validate them.
+When neither an invocation nor a delegation is present, protected routes return **401**:
+
+```text
+Missing UCAN authentication: provide Authorization: Bearer <invocation> with X-Auth-Type: ucan, or an x-ucan-delegation header
+```
+
+A malformed or expired invocation returns **401** `Invalid UCAN invocation`. Public routes ignore auth headers and don't validate them.
 
 ## CORS
 
@@ -32,9 +40,9 @@ Public routes ignore auth headers and don't validate them.
 Allowed request headers:
 
 ```text
-Content-Type, Authorization,
-x-ucan-delegation, x-matrix-access-token, x-matrix-homeserver,
-x-did, x-request-id, x-timezone
+Content-Type, Authorization, x-ucan-delegation,
+x-matrix-access-token, x-matrix-homeserver,
+x-did, x-request-id, x-auth-type, x-timezone
 ```
 
 Allowed methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `OPTIONS`.
@@ -45,44 +53,126 @@ Exposed response headers: `X-Request-Id`.
 
 | Route | Method | Auth | Purpose |
 | --- | --- | --- | --- |
-| `/health` | GET | Public | Liveness probe. |
+| `/` | GET | Public | Landing JSON (`{ status, message, timestamp }`). |
+| `/health` | GET | Public | Liveness probe (`{ status, timestamp }`). |
 | `/docs` | GET | Public | Swagger UI. |
 | `/docs/(.*)` | GET | Public | Swagger static assets. |
 
 Plus any route returned by a plugin's `getAuthExcludedRoutes()` or by `createOracleApp({ authExcludedRoutes })`.
 
-## Protected routes (overview)
+## Protected routes
 
-The runtime ships these modules:
+All of these require the auth headers above. For the request/response schemas of your specific deployment, hit `GET /docs`.
 
-- **`SessionsModule`** — manage chat sessions (`/sessions`).
-- **`MessagesModule`** — send and stream messages (`/messages`).
-- **`WsModule`** — WebSocket gateway for event streaming.
-- **`SubscriptionModule`** — credit/subscription gating middleware (active when `credits` plugin is loaded).
+### Sessions (`/sessions`)
 
-Plugins can contribute additional routes via `getNestModules()`. Bundled examples:
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/sessions` | POST | Create a chat session. Returns the new `sessionId`. |
+| `/sessions?limit&offset` | GET | List the authenticated user's sessions (paginated; defaults `limit=20`, `offset=0`). |
+| `/sessions/:sessionId` | DELETE | Delete a session. |
 
-- **`SlackModule`** — Slack webhook endpoints (when `slack` plugin is loaded).
-- **`UserPreferencesController`** — `/user-preferences` CRUD (when `user-preferences` plugin is loaded).
-- **`ClaimProcessingModule`** — claim cron endpoints (when `credits` plugin is fully configured).
+### Messages (`/messages`)
 
-For the authoritative route list and request/response schemas of your deployment, hit `GET /docs`. The shape is generated from your app's controllers — including plugin and host routes — so it's always in sync.
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/messages/:sessionId` | POST | Send a message. Set `stream: true` in the body for an SSE stream instead of a single JSON reply. |
+| `/messages/:sessionId` | GET | List the messages in a session. |
+| `/messages/abort` | POST | Abort an in-flight stream. Body: `{ "sessionId": "..." }`. |
 
-## WebSocket events
+`POST /messages/:sessionId` body (`SendMessageDto`):
 
-Plugins emit typed events via `rtCtx.emit`. The framework forwards them over the active WebSocket connection to the client.
+| Field | Type | Notes |
+| --- | --- | --- |
+| `message` | string | **Required.** The user's message text. |
+| `stream` | boolean | `true` → SSE stream; otherwise a single JSON reply. Default `false`. |
+| `returnAllMessages` | boolean | Non-stream only: also return the full transcript. Testing aid. Default `false`. |
+| `tools` | array | Browser-tool declarations (`{ name, schema, description }`). |
+| `agActions` | array | AG-UI action declarations (`{ name, description, schema, hasRender? }`). |
+| `attachments` | array | Up to 10 Matrix attachments (`mxcUri` or `eventId`, plus `filename`, `mimetype`). |
+| `mcpInvocations` | object | Map of MCP tool name → base64 CAR invocation for protected MCP tools. |
+| `timezone` | string | Overrides `rtCtx.user.timezone`. |
+| `homeServer` | string | The user's Matrix homeserver. |
+| `metadata` | object | Free-form (`editorRoomId`, `spaceId`, …). |
+
+Streaming is a flag on this single endpoint — there is no separate `/stream` route.
+
+### Delegation (`/delegation`)
+
+A user→oracle UCAN delegation lets the oracle mint downstream-service invocations on the user's behalf. The client-sdk re-auth popup POSTs here; a non-React client must implement this to complete the authorization flow.
+
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/delegation` | POST | Store a freshly-signed delegation. Returns `{ ok: true, expiration? }`. |
+| `/delegation` | GET | Authorization status: `{ authorized: boolean, expiration? }`. |
+| `/delegation` | DELETE | Revoke the stored delegation. Returns `{ ok: true }`. |
+
+`POST /delegation` body (`StoreDelegationDto`):
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `raw` | string | **Required.** Base64-encoded UCAN delegation CAR (user → oracle). |
+| `issuer` | string | Delegation issuer DID (the user). |
+| `audience` | string | Delegation audience DID (this oracle). |
+| `expiration` | number | Unix timestamp, seconds. |
+
+### Other modules
+
+- **`SubscriptionModule`** — credit/subscription gating middleware (active when the `credits` plugin is loaded).
+- **`WsModule`** — the WebSocket gateway (see below).
+
+Plugins contribute more routes via `getNestModules()` — e.g. `SlackModule` (Slack webhooks), `UserPreferencesController` (`/user-preferences`), and claim-processing cron endpoints. The Swagger UI at `/docs` is generated from your app's controllers — including plugin and host routes — so it's always the authoritative, deployment-specific list.
+
+## WebSocket
+
+The oracle runs a socket.io gateway on namespace `/`. Plugins emit typed events via `rtCtx.emit`; the framework forwards them to the client over the session's room.
+
+### Handshake
+
+Connect with a `sessionId` query param and a UCAN in `auth`. A handshake with no `sessionId`, or with no valid UCAN, is disconnected immediately.
+
+```ts
+import { io } from 'socket.io-client';
+
+const socket = io('https://your-oracle.example', {
+  query: { sessionId },
+  auth: {
+    invocation,      // primary: the user-signed UCAN invocation
+    ucanDelegation,  // fallback: a bare delegation (pre-invocation clients)
+  },
+});
+```
+
+The server validates the invocation (primary) or delegation (fallback) the same way HTTP requests do; the authenticated DID is the validated invoker, never the query value. On success it emits `connected`.
+
+### Server → client events
 
 | Event | When it fires |
 | --- | --- |
-| `toolCall` | A tool is being invoked (or has returned). |
-| `actionCall` | An action (e.g. AG-UI action) is being invoked. |
-| `renderComponent` | A render component result is ready for the client. |
-| `reasoning` | The agent emits intermediate reasoning. |
-| `browserToolCall` | A browser-side tool is being invoked on the user's Portal. |
-| `router` | Routing decision between agents/sub-agents. |
-| `messageCacheInvalidation` | A message cache entry should be invalidated. |
+| `connected` | Handshake accepted. |
+| `pong` | Reply to a `ping`. |
+| `status` | Reply to a `status` request (connection stats). |
+| `subscribed` | Subscription acknowledged. |
+| `available-events` | Reply to `list-events` — the full event catalog. |
+| `tool_call` | A tool is being invoked (or has returned). |
+| `action_call` | An AG-UI action is being invoked. |
+| `render_component` | A render-component result is ready for the client. |
+| `browser_tool_call` | A browser-side tool is being invoked on the user's tab. |
+| `router_update` | A routing decision between agents/sub-agents. |
+| `message_cache_invalidation` | A cached message should be dropped. |
 
-Payload types are currently `Record<string, unknown>` and may be tightened in future runtime versions. The `@ixo/oracles-client-sdk` React SDK parses these and renders them.
+### Client → server events
+
+| Event | Purpose |
+| --- | --- |
+| `ping` | Keep-alive; server replies `pong`. |
+| `status` | Request connection stats; server replies `status`. |
+| `subscribe` | Subscribe to session events. |
+| `list-events` | Ask for the event catalog; server replies `available-events`. |
+| `tool_result` | Return a browser-tool result (`{ toolCallId, result, error? }`). |
+| `action_call_result` | Return an AG-UI action result (`{ sessionId, toolCallId, result }`). |
+
+Event payload types are currently `Record<string, unknown>` and may be tightened in future runtime versions. The `@ixo/oracles-client-sdk` React SDK handles this handshake, parses these events, and renders them.
 
 ## Client SDK
 

--- a/build-an-oracle/reference/bundled-plugins/agui.mdx
+++ b/build-an-oracle/reference/bundled-plugins/agui.mdx
@@ -8,6 +8,7 @@ icon: "table"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `agui` |
 | Visibility | `on-demand` |
 | Stability | `stable` |
 | Category | `ui` |

--- a/build-an-oracle/reference/bundled-plugins/calls.mdx
+++ b/build-an-oracle/reference/bundled-plugins/calls.mdx
@@ -8,13 +8,28 @@ icon: "phone"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `calls` |
+| Version | `0.0.0` |
 | Visibility | `silent` |
 | Stability | `experimental` |
-| Default state | Stub (no auto-detect) |
+| Default state | Loaded by default (stub — contributes nothing) |
+
+<Warning>
+`calls` is a **placeholder stub**, not a shipped feature. It is the only bundled entry created via `stub('calls', 'Calls')` in `plugins/index.ts` — version `0.0.0`, no tools, no sub-agents, no middleware, no Nest modules. Don't rely on it.
+</Warning>
 
 ## Status: deferred
 
-`calls` is a **stub** entry in `BUNDLED_PLUGINS` so feature toggles work. The legacy `apps/app` codebase had a `@Controller('calls')` for LiveKit integration; the `getNestModules` API hook would technically unblock a real implementation. Deferred for now.
+`calls` exists in `BUNDLED_PLUGINS` only so the `features` toggle key resolves. Because it declares no `autoDetect`, the loader loads it by default — but it contributes nothing, so loading it has no effect. The legacy `apps/app` codebase had a `@Controller('calls')` for LiveKit integration; the `getNestModules` API hook would technically unblock a real implementation. Deferred for now.
+
+It contributes nothing, so there is nothing to enable. You can keep it from loading at all with:
+
+```ts
+const app = await createOracleApp({
+  config,
+  features: { calls: false }, // skip the stub entirely
+});
+```
 
 See the framework's [follow-ups](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/docs/spec-and-roadmap/follow-ups.md) for the rebuild plan.
 

--- a/build-an-oracle/reference/bundled-plugins/composio.mdx
+++ b/build-an-oracle/reference/bundled-plugins/composio.mdx
@@ -8,6 +8,7 @@ icon: "plug"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `composio` |
 | Visibility | `on-demand` |
 | Stability | `stable` |
 | Category | `integration` |
@@ -28,11 +29,21 @@ Hundreds of SaaS tools (Gmail, GitHub, Linear, Slack, Google Calendar, Notion, J
 
 ## What it contributes
 
-- **Tools:** dynamic catalog returned per request (one tool per upstream Composio tool, e.g. `COMPOSIO_MANAGE_CONNECTIONS`, `COMPOSIO_SEARCH_TOOLS`, plus toolkit-specific actions).
+Composio is a **tool router**, not a 1:1 catalog. Per request the session returns a small fixed set of directly-callable meta-tools; the thousands of app-specific tools (e.g. `GMAIL_SEND_EMAIL`, `COMPOSIO_SEARCH_FINANCE`) are **not** bound to the agent — they are discovered and then executed through the router.
+
+- **Tools (the four router meta-tools):**
+  - `COMPOSIO_MANAGE_CONNECTIONS` — check / start a toolkit's auth connection (returns a `redirect_url` when the user must connect).
+  - `COMPOSIO_SEARCH_TOOLS` — describe an action in natural language to find the exact tool slug(s).
+  - `COMPOSIO_GET_TOOL_SCHEMAS` — fetch the exact input schema for one or more discovered slugs.
+  - `COMPOSIO_MULTI_EXECUTE_TOOL` — run one or more discovered tools by slug. App-specific tools are executed here, never bound directly.
 - **Sub-agents:** none.
 - **Middleware:** none.
 - **HTTP routes:** none.
 - **Shared state:** none.
+
+<Note>
+The exact tool set is returned dynamically by the composio-worker session, so it can vary by user/connection. The plugin pins only the `COMPOSIO_MULTI_EXECUTE_TOOL` argument envelope (see below) — every slug lives in Composio's registry, not in the runtime.
+</Note>
 
 ## Opt out / Opt in
 
@@ -45,13 +56,35 @@ const app = await createOracleApp({
 });
 ```
 
+## The discover → execute flow
+
+App-specific tools are never callable directly. The agent follows a fixed four-step flow (this is the `whenToUse` guidance that ships in the manifest and reaches the model):
+
+1. **Connect** — for any connected-app action, call `COMPOSIO_MANAGE_CONNECTIONS` with the toolkit FIRST. If it returns a `redirect_url`, surface it as a clickable markdown link and stop. (Pure search tools — the `COMPOSIO_SEARCH_*` family — need no connection.)
+2. **Discover** — call `COMPOSIO_SEARCH_TOOLS`, describing the action in natural language, to find the exact tool slug(s).
+3. **Inspect (if unsure)** — call `COMPOSIO_GET_TOOL_SCHEMAS` with those slugs to fetch their exact input schema.
+4. **Execute** — call `COMPOSIO_MULTI_EXECUTE_TOOL` with the discovered slug(s).
+
+The execute envelope is strict — exactly `tools` + `sync_response_to_workbench`, with each call wrapped as `tool_slug` + `arguments`:
+
+```json
+{
+  "tools": [
+    { "tool_slug": "COMPOSIO_SEARCH_FINANCE", "arguments": { "query": "Bitcoin price USD today" } }
+  ],
+  "sync_response_to_workbench": false
+}
+```
+
+Never pass a tool name as a top-level key (e.g. `{ "COMPOSIO_SEARCH_FINANCE": {...} }`) — always wrap it inside the `tools` array.
+
 ## When to use it
 
-- ALWAYS call `COMPOSIO_MANAGE_CONNECTIONS` first — before calling any other Composio tool — to verify the required toolkit is connected. If the response contains a `redirect_url`, surface it as a clickable markdown link and stop; do not attempt the action.
 - User asks to send, read, or search emails (Gmail, Outlook).
 - User asks to create or modify issues, pull requests, or stars (GitHub, Linear, Jira).
 - User asks to manage calendar events, files, or documents in a SaaS app.
-- No native skill covers the requested action — call `COMPOSIO_SEARCH_TOOLS` before giving up.
+- Web, news, finance, academic, or trend searches — the `COMPOSIO_SEARCH_*` family covers these and needs no connection.
+- No native skill covers the requested action — discover what Composio offers with `COMPOSIO_SEARCH_TOOLS` before giving up.
 
 ## When NOT to use it
 

--- a/build-an-oracle/reference/bundled-plugins/credits.mdx
+++ b/build-an-oracle/reference/bundled-plugins/credits.mdx
@@ -8,6 +8,7 @@ icon: "coins"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `credits` |
 | Visibility | `silent` |
 | Stability | `stable` |
 | Category | `core` |

--- a/build-an-oracle/reference/bundled-plugins/domain-indexer.mdx
+++ b/build-an-oracle/reference/bundled-plugins/domain-indexer.mdx
@@ -8,6 +8,7 @@ icon: "database"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `domain-indexer` |
 | Visibility | `always` |
 | Stability | `stable` |
 | Category | `data` |

--- a/build-an-oracle/reference/bundled-plugins/editor.mdx
+++ b/build-an-oracle/reference/bundled-plugins/editor.mdx
@@ -8,10 +8,11 @@ icon: "pen-to-square"
 
 | Attribute | Value |
 | --- | --- |
-| Visibility | `on-demand` |
+| Feature key | `editor` |
+| Visibility | `always` |
 | Stability | `stable` |
 | Category | `data` |
-| Default state | On (needs an explicit Matrix client for production behaviour) |
+| Default state | On |
 | Depends on | — |
 
 ## Summary
@@ -43,9 +44,11 @@ The plugin owns no env vars. It reads the following from the core base env schem
 - **HTTP routes:** none.
 - **Shared state:** none.
 
-## Production constructor
+## Matrix client (optional)
 
-The bundled singleton works for inspect / test; production behaviour needs an explicit Matrix client:
+The bundled `editorPlugin` is fully functional from env. When no `matrixClient` is passed, the plugin lazily builds an internal Matrix client from the `MATRIX_*` admin env vars (`MATRIX_BASE_URL`, `MATRIX_ORACLE_ADMIN_USER_ID`, `MATRIX_ORACLE_ADMIN_ACCESS_TOKEN`). So you do **not** need to construct it explicitly for production.
+
+Pass a `matrixClient` only as a reuse optimization — when your app already keeps a long-lived `matrix-js-sdk` client synced and you want the editor tools to share it:
 
 ```ts
 import { createOracleApp, EditorPlugin } from '@ixo/oracle-runtime';
@@ -55,7 +58,7 @@ const matrixClient = sdk.createClient({ /* … */ });
 
 const app = await createOracleApp({
   config,
-  plugins: [new EditorPlugin({ matrixClient })],
+  plugins: [new EditorPlugin({ matrixClient })], // optional — env fallback otherwise
 });
 ```
 

--- a/build-an-oracle/reference/bundled-plugins/firecrawl.mdx
+++ b/build-an-oracle/reference/bundled-plugins/firecrawl.mdx
@@ -8,6 +8,7 @@ icon: "globe"
 
 | Attribute | Value |
 | --- | --- |
+| Feature key | `firecrawl` |
 | Visibility | `on-demand` |
 | Stability | `stable` |
 | Category | `data` |

--- a/build-an-oracle/reference/bundled-plugins/memory.mdx
+++ b/build-an-oracle/reference/bundled-plugins/memory.mdx
@@ -53,7 +53,7 @@ Memory context does not arrive in the prompt because the agent calls a tool to f
 
 **When it runs:** at agent-compile time, before turn 1. The fetcher runs once per session and caches the result for **5 minutes** (keyed by `sessionId`). Subsequent turns within the same session reuse the cached context — the Memory Engine is not called again unless the cache expires.
 
-**What appears in the prompt:** if at least one slot is non-empty, the runtime inserts a `## What you know about the user` block (section 6 of the 15-section prompt) containing all populated slots. If every slot is empty (no prior memory for this user), the block is omitted entirely.
+**What appears in the prompt:** if at least one slot is non-empty, the runtime inserts a `## What you know about the user` block into the system prompt containing all populated slots. If every slot is empty (no prior memory for this user), the block is omitted entirely.
 
 **Implication for oracle authors:** you do not need to instruct the agent to "look up the user's context" or "recall memory before responding" in `config.prompt.opening` or anywhere else. The context is already in the system prompt when the agent sees the user's first message. Adding such instructions is redundant and wastes tokens.
 

--- a/build-an-oracle/reference/bundled-plugins/overview.mdx
+++ b/build-an-oracle/reference/bundled-plugins/overview.mdx
@@ -17,12 +17,12 @@ The runtime bundles 15 plugins. They load by default; opt out per plugin via the
 | [`composio`](/build-an-oracle/reference/bundled-plugins/composio) | `on-demand` | Auto-detect | `COMPOSIO_API_KEY` | — |
 | [`sandbox`](/build-an-oracle/reference/bundled-plugins/sandbox) | `always` | Auto-detect | `SANDBOX_MCP_URL` | — |
 | [`skills`](/build-an-oracle/reference/bundled-plugins/skills) | `always` | On | — | `sandbox` |
-| [`editor`](/build-an-oracle/reference/bundled-plugins/editor) | `on-demand` | On (needs Matrix client) | — | — |
+| [`editor`](/build-an-oracle/reference/bundled-plugins/editor) | `always` | On | — | — |
 | [`agui`](/build-an-oracle/reference/bundled-plugins/agui) | `on-demand` | On | — | — |
 | [`slack`](/build-an-oracle/reference/bundled-plugins/slack) | `silent` | Auto-detect | `SLACK_BOT_OAUTH_TOKEN` | — |
-| [`tasks`](/build-an-oracle/reference/bundled-plugins/tasks) | (stub) | Auto-detect (stub) | `REDIS_URL` | — |
+| [`tasks`](/build-an-oracle/reference/bundled-plugins/tasks) | `on-demand` | Auto-detect | `REDIS_URL` | — |
 | [`credits`](/build-an-oracle/reference/bundled-plugins/credits) | `silent` | On unless `DISABLE_CREDITS=true` | — | — |
-| [`calls`](/build-an-oracle/reference/bundled-plugins/calls) | (stub) | On (stub) | — | — |
+| [`calls`](/build-an-oracle/reference/bundled-plugins/calls) | `silent` | On (stub) | — | — |
 | [`user-preferences`](/build-an-oracle/reference/bundled-plugins/user-preferences) | `always` | On | — | — |
 | [`matrix-group-chats`](/build-an-oracle/reference/bundled-plugins/matrix-group-chats) | `on-demand` | On | — | — |
 
@@ -81,7 +81,7 @@ const app = await createOracleApp({
     Slack bot transport.
   </Card>
   <Card title="tasks" icon="hourglass" href="/build-an-oracle/reference/bundled-plugins/tasks">
-    Background jobs (stub — deferred).
+    Schedule the agent to run on time-based triggers, in the background.
   </Card>
   <Card title="credits" icon="coins" href="/build-an-oracle/reference/bundled-plugins/credits">
     Per-user credit enforcement and claim settlement.
@@ -99,26 +99,35 @@ const app = await createOracleApp({
 
 ## Wiring custom-constructed plugins
 
-Two plugins need constructor args for production behaviour. Pass them via the `plugins` array (the loader dedupes by name, so your instance overrides the bundled default):
+Some plugins accept constructor args. Pass a custom instance via the `plugins` array — the loader dedupes by name, so your instance overrides the bundled default.
+
+**`credits` genuinely needs a Redis client.** Without one the enforcement middleware loads in pass-through mode and the settlement cron is skipped, so production must construct it explicitly:
 
 ```ts
-import { createOracleApp, EditorPlugin, CreditsPlugin } from '@ixo/oracle-runtime';
-import * as sdk from 'matrix-js-sdk';
+import { createOracleApp, CreditsPlugin } from '@ixo/oracle-runtime';
 import Redis from 'ioredis';
 
-const matrixClient = sdk.createClient({ /* ... */ });
-const redis = process.env.REDIS_URL ? new Redis(process.env.REDIS_URL) : null;
+const redis = new Redis(process.env.REDIS_URL!);
 
 const app = await createOracleApp({
   config,
-  plugins: [
-    new EditorPlugin({ matrixClient }),
-    ...(redis ? [new CreditsPlugin({ redis, network: 'devnet' })] : []),
-  ],
+  plugins: [new CreditsPlugin({ redis, network: 'devnet' })],
 });
 ```
 
-The bundled `editorPlugin` and `creditsPlugin` singletons in `BUNDLED_PLUGINS` work in stub form for tests; for real behaviour, instantiate explicitly.
+**`editor` works from env on its own.** The bundled `editorPlugin` is fully functional: when no `matrixClient` is passed it lazily builds an internal Matrix client from the `MATRIX_*` admin env vars. Pass `matrixClient` only to reuse a client your app already keeps synced:
+
+```ts
+import { createOracleApp, EditorPlugin } from '@ixo/oracle-runtime';
+import * as sdk from 'matrix-js-sdk';
+
+const matrixClient = sdk.createClient({ /* ... */ });
+
+const app = await createOracleApp({
+  config,
+  plugins: [new EditorPlugin({ matrixClient })], // optional — env fallback otherwise
+});
+```
 
 ## Read next
 

--- a/build-an-oracle/reference/bundled-plugins/sandbox.mdx
+++ b/build-an-oracle/reference/bundled-plugins/sandbox.mdx
@@ -28,7 +28,8 @@ Per-user Linux sandbox. `sandbox_run` runs shell/python (writes anywhere via she
 
 ## What it contributes
 
-- **Tools:** every upstream MCP tool — `sandbox_run`, `sandbox_write_file`, the `artifact_*` family, `load_skill`. By default the `oracle_*` management tools (`oracle_list`, `oracle_get`, `oracle_health`, `oracle_stop`, `oracle_restart`, `oracle_get_logs`) are filtered out; opt in with `new SandboxPlugin({ includeOracleManagementTools: true })`.
+- **Tools:** every upstream MCP tool — `sandbox_run`, `sandbox_write_file`, the `artifact_*` family, `load_skill` — passed through verbatim. By default the `oracle_*` management tools (`oracle_list`, `oracle_get`, `oracle_health`, `oracle_stop`, `oracle_restart`, `oracle_get_logs`) are filtered out; opt in with `new SandboxPlugin({ includeOracleManagementTools: true })`.
+  - Plus one synthetic, non-upstream tool: `sandbox_write_blob` — takes a server-stored `blobId` + a sandbox path, looks the value up server-side, and forwards it to `sandbox_write_file` (the companion to blob storage). It is added per request only when `sandbox_write_file` is present upstream **and** the request has a known user DID (the blob store is namespaced by user DID).
 - **Sub-agents:** none.
 - **Middleware:** none.
 - **HTTP routes:** none.

--- a/build-an-oracle/reference/bundled-plugins/skills.mdx
+++ b/build-an-oracle/reference/bundled-plugins/skills.mdx
@@ -12,7 +12,7 @@ icon: "code"
 | Stability | `stable` |
 | Category | `data` |
 | Default state | On |
-| Depends on | `sandbox` (hard dep — boot fails without it) |
+| Depends on | `sandbox` (hard dep — see below) |
 
 ## Summary
 
@@ -24,6 +24,10 @@ Discover IXO skill capsules. Both `list_skills` and `search_skills` mint an `ixo
 | --- | --- | --- |
 | `SKILLS_CAPSULES_BASE_URL` | no | Defaults to `https://capsules.skills.ixo.earth`. |
 | `NETWORK` | no | Read but not owned (declared by the core base env schema). Forwarded as `X-IXO-Network`. |
+
+## Depends on
+
+Hard-depends on [`sandbox`](/build-an-oracle/reference/bundled-plugins/sandbox) — skill *execution* runs through `sandbox_run`, which `sandbox` owns (listing/search is HTTP-only). But `sandbox` is auto-detect (`SANDBOX_MCP_URL`) and off by default, while `skills` is on by default. If `sandbox` is not loaded — e.g. `SANDBOX_MCP_URL` is unset — the loader **cascades `skills` off silently** (a `boot.plugin.cascaded_off` warning), it does **not** fail boot. A true boot failure only occurs if `sandbox` is removed from the plugin set entirely while `skills` still requires it.
 
 ## What it contributes
 

--- a/build-an-oracle/reference/bundled-plugins/slack.mdx
+++ b/build-an-oracle/reference/bundled-plugins/slack.mdx
@@ -59,6 +59,6 @@ const app = await createOracleApp({
     Nest-module contribution pattern.
   </Card>
   <Card title="Visibility tiers" icon="layer-group" href="/build-an-oracle/understand/visibility-tiers">
-    Why `silent` plugins are invisible to the agent.
+    What `silent` visibility means (here, the plugin has no tools at all).
   </Card>
 </CardGroup>

--- a/build-an-oracle/reference/bundled-plugins/tasks.mdx
+++ b/build-an-oracle/reference/bundled-plugins/tasks.mdx
@@ -1,36 +1,126 @@
 ---
 title: "tasks"
-description: "Background jobs plugin — stub. Full implementation deferred."
-icon: "hourglass"
+description: "Schedule the main agent to run on time-based triggers and deliver results to the user's chat — in the background, not inline."
+icon: "clock"
 ---
 
-**Source:** [`packages/oracle-runtime/src/plugins/index.ts`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugins/index.ts) (stub manifest)
+**Source:** [`packages/oracle-runtime/src/plugins/tasks/`](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/packages/oracle-runtime/src/plugins/tasks/)
 
 | Attribute | Value |
 | --- | --- |
-| Visibility | `silent` |
-| Stability | `experimental` |
-| Default state | Stub (auto-detects on `REDIS_URL`) |
+| Feature key | `tasks` |
+| Visibility | `on-demand` |
+| Stability | `beta` |
+| Category | `automation` |
+| Default state | Auto-detect (env: `REDIS_URL`) |
+| Depends on | — |
+| Soft-depends on | `memory` |
 
-## Status: deferred
+## Summary
 
-`tasks` is a **stub** entry in `BUNDLED_PLUGINS` so feature toggles and the `REDIS_URL` auto-detect hint work, but no functionality is wired. The original port revealed contract violations that need rework before a full implementation lands.
+Lets the agent schedule itself to run later. A task is a saved spec (title + intent) plus a trigger (`time.once` or `time.cron`). When the trigger fires, the runtime starts a **fresh background session** — no memory of the conversation that created it — runs one agent turn, and delivers the result to the user's main oracle room or a dedicated `[Task]` room. The agent owns the whole lifecycle through 10 tools, a mandatory **preview → create** approval flow, and an optional per-run **before-action** approval gate.
 
-See the framework's [follow-ups](https://github.com/ixoworld/ixo-oracles-boilerplate/blob/main/docs/spec-and-roadmap/follow-ups.md) and the task spec at `specs/tasks/` for the rebuild plan.
+<Note>
+Because each run is a fresh session, every ID, URL, name, or reference the run needs must be written into `intent.context` when the task is created. The run cannot "remember" anything discussed in the chat that scheduled it.
+</Note>
 
-## Environment variables (when implemented)
+## Environment variables
 
-| Var | Required | Description |
+| Var | Required | Default | Description |
+| --- | --- | --- | --- |
+| `REDIS_URL` | yes | — | Redis connection URL. Backs the BullMQ `task_run` queue + worker and the task state store. Triggers auto-detect. |
+| `TASKS_MAX_PER_USER` | no | `50` | Max live tasks per user (not counting `cancelled` / `completed`). `create_task` rejects new tasks past this. |
+| `TASKS_RUN_LOCK_TTL_SEC` | no | `600` | TTL (seconds) on a run's execution lock — guards against a double-fire running the same task twice. |
+| `TASKS_MIN_CRON_INTERVAL_SEC` | no | `300` | Floor (seconds) on how often a `time.cron` trigger may fire. Faster schedules are rejected at create/update time. |
+
+## Depends on
+
+Soft-depends on [`memory`](/build-an-oracle/reference/bundled-plugins/memory): tasks loads and runs fine if `memory` is absent, but background runs lose durable per-user context. A `boot.plugin.soft_dep_missing` log line is emitted when `memory` is not loaded — it is a warning, never a boot failure.
+
+## What it contributes
+
+- **Tools (10, `on-demand`):** the agent loads them via the capability gate before use.
+  - `preview_task` — run a candidate spec **once, for real**, and return the output + a `previewToken`. Always required before scheduling; the agent must show the user this output and stop.
+  - `create_task` — schedule a previewed task. Requires a matching `previewToken` minted in an **earlier** turn (re-preview if anything changed). Picks `time.once` vs `time.cron` and the delivery room.
+  - `list_my_tasks` — list the user's tasks (id, title, status, trigger, next run); optional status filter.
+  - `get_task` — full spec body, status, trigger, delivery room, and the last error if it has been failing.
+  - `update_task` — patch title, trigger, approval mode, or intent. Changing the intent needs a fresh `previewToken`; changing the trigger reschedules automatically.
+  - `pause_task` — pause a task; pending runs are cancelled until resumed.
+  - `resume_task` — resume a paused, `pending-approval`, or `failed-pending-review` task; recomputes the next run.
+  - `cancel_task` — cancel permanently (spec kept for the audit trail).
+  - `resolve_task_approval` — record the user's decision (`approved` / `declined`) after a **nuanced** reply in a `[Task]` room. Plain yes/no replies are recorded automatically — don't call this for those.
+  - `suggest_spec_fix` — for a failing task, return the current body + last error so the agent can propose a revision (applied via `update_task` only after the user agrees).
+- **Sub-agents:** none.
+- **Middleware:** one — `TaskRoomApprovalGate`. Wraps every model call but only acts inside a dedicated task room whose task is `pending-approval`. A plain yes/no reply is classified and resolved deterministically **before** the model runs; nuanced replies get a system-prompt hint pointing the model at `resolve_task_approval`. It never short-circuits the turn and never posts to Matrix.
+- **HTTP routes:** none.
+- **Nest module:** `TasksModule` — owns the BullMQ `task_run` queue + `TaskRunWorker`, a Redis-backed state/task store, the scheduler, delivery service, agent invoker, and approval flow. On init it registers a room→session resolver on the Matrix bridge so a plainly-typed reply in a task room continues that run's own thread instead of starting a fresh one.
+- **Shared state:** none.
+
+## Triggers
+
+| Type | Fields | Use for |
 | --- | --- | --- |
-| `REDIS_URL` | yes | Will trigger auto-detect when the real plugin lands. |
+| `time.once` | `runAtIso` (ISO datetime), `tz` | One-time requests — "in 10 minutes", "tomorrow at 5pm". Compute `runAtIso` from now. |
+| `time.cron` | `pattern` (cron), `tz` | Genuinely recurring schedules — "every morning at 7". `*/10 * * * *` means every-10-minutes-forever, not once-in-10-minutes. |
+
+## The preview → create flow
+
+Scheduling is always two turns:
+
+<Steps>
+  <Step title="preview_task">
+    The agent runs the candidate spec once with live tools and returns the real output plus a `previewToken`. It then **stops** and shows the output to the user — it must not call `create_task` in the same turn.
+  </Step>
+  <Step title="User confirms in a new message">
+    The user replies to schedule it (and optionally asks for a dedicated room or per-run approval).
+  </Step>
+  <Step title="create_task">
+    Called with the same title/intent and the `previewToken`. The runtime re-checks the token (owner + content hash + a different request id), enforces the per-user limit and the cron floor, saves the spec, and enqueues the first run.
+  </Step>
+</Steps>
+
+## Before-action approval
+
+Set `approval: 'before-action'` (with `intent.requiresApproval` naming the guarded action) when a run would send, post, publish, or create something on the user's behalf. Such tasks always get their own `[Task]` room. Each run does the work, **drafts** the action, and asks the user to approve by replying in that room:
+
+- A plain "yes" / "no" (and close variants) is recorded deterministically by the `TaskRoomApprovalGate` middleware before the model runs.
+- A nuanced reply ("fix the typo first, then send") is handled by the agent, which acts on it and then calls `resolve_task_approval`.
+
+## Task statuses
+
+`active` · `pending-approval` · `paused` · `failed-pending-review` · `completed` · `cancelled`.
+
+## Opt out / Opt in
+
+`tasks` auto-detects on `REDIS_URL` and is off when that env var is unset.
+
+```ts
+const app = await createOracleApp({
+  config,
+  features: { tasks: false }, // never load
+  // features: { tasks: true }, // force load (fails env validation if REDIS_URL missing)
+  // features: { tasks: 'auto' }, // run autoDetect (default — loads when REDIS_URL is set)
+});
+```
+
+## When to use it
+
+- The user wants a reminder or recurring report ("every morning at 7", "tomorrow at 5pm", "remind me to…").
+- The user wants the agent to monitor or track something on a schedule.
+- The user wants a piece of work run later, in the background, without sitting in the chat.
+
+## When NOT to use it
+
+- A one-shot action the user wants done right now — just do it inline.
+- Real-time / streaming requirements — tasks run on a scheduled cadence, not on demand.
 
 ## Where to read next
 
 <CardGroup cols={2}>
-  <Card title="Bundled plugins" icon="boxes-stacked" href="/build-an-oracle/reference/bundled-plugins/overview">
-    The full bundled set.
+  <Card title="memory" icon="brain" href="/build-an-oracle/reference/bundled-plugins/memory">
+    Soft dependency — durable per-user context for background runs.
   </Card>
-  <Card title="Plugin anatomy" icon="diagram-subtask" href="/build-an-oracle/understand/plugin-anatomy">
-    What a real plugin looks like.
+  <Card title="Visibility tiers" icon="layer-group" href="/build-an-oracle/understand/visibility-tiers">
+    Why `on-demand` tools are loaded through the capability gate.
   </Card>
 </CardGroup>

--- a/build-an-oracle/reference/cli.mdx
+++ b/build-an-oracle/reference/cli.mdx
@@ -4,7 +4,7 @@ description: "Every qiforge-cli command — installation, authentication, oracle
 icon: "terminal"
 ---
 
-`qiforge-cli` ([source](https://github.com/ixoworld/ixo-oracles-cli)) scaffolds new oracles, scaffolds new plugins inside an existing oracle, provisions on-chain identity + Matrix bots, and gives you an SSE chat client for testing.
+The CLI installs from the `qiforge-cli` npm package and runs as the `qiforge-cli` binary ([source](https://github.com/ixoworld/ixo-oracles-cli)). It scaffolds new oracles, scaffolds new plugins inside an existing oracle, provisions on-chain identity + Matrix bots, and gives you an SSE chat client for testing.
 
 ## Installation
 
@@ -34,19 +34,20 @@ Requires Node 22+. Authentication needs either the IXO Mobile App (SignX QR) or 
 | Command | Purpose |
 | --- | --- |
 | `qiforge-cli` | Interactive menu (auth → choose command). |
-| `qiforge-cli --init` / `qiforge-cli init` | Clone the QiForge boilerplate, create entity, write `.env`. |
-| `qiforge-cli new <name>` | Scaffold a standalone oracle from bundled code templates (no git clone). |
+| `qiforge-cli new <name>` | Scaffold a new oracle from the bundled starter. |
 | `qiforge-cli plugin new <name>` | Scaffold a new plugin into an existing oracle project. |
 | `qiforge-cli create-entity` | Create the on-chain entity record + Matrix bot. |
 | `qiforge-cli update-entity` | Update an existing entity (e.g. add controllers). |
-| `qiforge-cli update-oracle-api-url` | Update the oracle's API URL (default is `localhost`). |
-| `qiforge-cli setup-encryption-key` | Set up the P-256 encryption key for an existing oracle. |
+| `qiforge-cli update-oracle-api-url` | Update the oracle's registered API URL/domain. |
+| `qiforge-cli setup-encryption-key` | Provision the oracle's encryption/signing key. |
 | `qiforge-cli create-composio-key` | Mint a Composio API key tied to the oracle. |
 | `qiforge-cli create-user` | Create a new user account. |
-| `qiforge-cli chat` | Stream messages to a running oracle over SSE. |
+| `qiforge-cli signx-login` | Authenticate via SignX QR (IXO Mobile App). |
 | `qiforge-cli offline-login` | Authenticate with a local mnemonic (no mobile app). |
 | `qiforge-cli logout` | Clear stored credentials. |
-| `qiforge-cli --help`, `-h` | Show help. |
+| `qiforge-cli help` | Show help. |
+| `--chat` | Flag — start a chat session with a running oracle. |
+| `--help`, `-h` | Flag — show help. |
 
 ## Authentication
 
@@ -57,8 +58,8 @@ Two modes:
     Uses the IXO Mobile App for QR-code-based authentication. Keep the app open during the session.
 
     ```sh
-    qiforge-cli
-    # Select "SignX Wallet (QR code with mobile app)" when prompted.
+    qiforge-cli signx-login
+    # Scan the QR code with the IXO Mobile App when prompted.
     ```
   </Accordion>
 
@@ -90,53 +91,38 @@ Two modes:
   </Accordion>
 </AccordionGroup>
 
-## qiforge-cli --init
-
-Scaffolds a new oracle project end-to-end by cloning the [QiForge boilerplate](https://github.com/ixoworld/qiforge):
-
-- Creates a project directory and clones the boilerplate.
-- Creates a blockchain entity with linked resources stored in Matrix.
-- Provisions a Matrix bot account.
-- Writes `oracle.config.json` and `.env`.
-
-Interactive:
-
-```sh
-qiforge-cli --init
-```
-
-Non-interactive (for CI):
-
-```sh
-qiforge-cli --init --no-interactive \
-  --name my-oracle-project \
-  --network devnet \
-  --oracle-name "My Oracle" \
-  --price 100 \
-  --api-url http://localhost:4000 \
-  --pin 123456
-```
-
-**Init flags:**
-
-| Flag | Description | Default |
-| --- | --- | --- |
-| `--name` | Project name (required in non-interactive mode). | — |
-| `--path` | Project directory path. | `./<name>` |
-| `--repo` | Template repository URL. | `git@github.com:ixoworld/qiforge.git` |
-| `--force` | Overwrite existing directory. | `false` |
-
-Plus all `create-entity` flags (see below).
-
 ## qiforge-cli new
 
-Scaffolds a standalone oracle from bundled code templates — no git clone. Faster than `--init`, doesn't need network access for the boilerplate, useful when you want a fork that diverges immediately.
+Scaffolds a new oracle from the bundled starter template — no git clone. Interactive by default: it walks you through auth, network, the oracle profile, and entity creation, then writes the project.
 
 ```sh
 qiforge-cli new my-oracle
 ```
 
-The command optionally runs `pnpm install` and can also create the oracle entity + Matrix account in the same flow.
+Non-interactive (for CI) — `--name` is required:
+
+```sh
+qiforge-cli new --no-interactive \
+  --name my-oracle \
+  --description "What this oracle does" \
+  --org "My Org" \
+  --install
+```
+
+**Flags:**
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--name` | Project name (required with `--no-interactive`). | — |
+| `--path` | Directory to scaffold into. | `./<name>` |
+| `--template` | Starter template. | `basic` |
+| `--description` | Oracle description. | — |
+| `--org` | Organisation name. | `IXO` |
+| `--install` | Run the package install after scaffolding. | `false` |
+| `--force` | Overwrite an existing directory. | `false` |
+| `--no-interactive` | Skip prompts (requires `--name`). | `false` |
+
+The command optionally runs the install step and can also create the oracle entity + Matrix account in the same flow.
 
 ## qiforge-cli plugin new
 
@@ -145,6 +131,8 @@ Scaffolds a new plugin into an **existing** oracle project. Run it from inside t
 ```sh
 qiforge-cli plugin new climate
 ```
+
+**Flag:** `--cwd` — the directory to resolve the oracle project from (defaults to the current directory).
 
 Generated layout (under `src/plugins/<name>/`):
 
@@ -160,7 +148,7 @@ Name validation: kebab-case, must not collide with bundled plugin names.
 
 ## qiforge-cli create-entity
 
-Creates the on-chain entity record and Matrix bot. Used both standalone (e.g. when re-provisioning) and as part of `--init`.
+Creates the on-chain entity record and Matrix bot, and writes `oracle.config.json` + `.env`. Used both standalone (e.g. when re-provisioning) and as part of `new`.
 
 ```sh
 qiforge-cli create-entity --no-interactive \
@@ -173,6 +161,10 @@ qiforge-cli create-entity --no-interactive \
   --model "anthropic/claude-sonnet-4" \
   --pin 123456
 ```
+
+<Note>
+`create-entity` registers `--api-url http://localhost:4000` by default, but the runtime's own default `PORT` is `3000`. If you take the default URL, make your running oracle reachable at it: either set `PORT=4000` in your `.env` to match, or update the registered URL later with `qiforge-cli update-oracle-api-url`.
+</Note>
 
 **Flags:**
 
@@ -221,7 +213,7 @@ Accepts account DIDs as controllers (in addition to entity DIDs).
 
 ## qiforge-cli update-oracle-api-url
 
-Updates the URL the oracle entity advertises. Default is `localhost:4000`; switch to your deployed URL before going live.
+Updates the URL the oracle entity advertises. Default is `http://localhost:4000`; switch to your deployed URL before going live.
 
 ```sh
 qiforge-cli update-oracle-api-url
@@ -229,11 +221,13 @@ qiforge-cli update-oracle-api-url
 
 ## qiforge-cli setup-encryption-key
 
-Provisions a P-256 `keyAgreement` encryption key for an existing oracle that was created before encryption was mandatory.
+Provisions the oracle's encryption/signing key into its Matrix account room — the P-256 `keyAgreement` key used to decrypt per-room secrets, plus the signing material the runtime uses to mint downstream UCAN invocations. Until it's provisioned, authenticated routes return 401 and the boot log warns about the missing key.
 
 ```sh
 qiforge-cli setup-encryption-key
 ```
+
+Run it once per oracle (and again after rotating the key).
 
 ## qiforge-cli create-composio-key
 
@@ -253,15 +247,15 @@ Creates a new user account (DID + Matrix account) — useful for testing your or
 qiforge-cli create-user
 ```
 
-## qiforge-cli chat
+## --chat
 
-Streams messages to a running oracle over SSE. Renders tool calls, assistant messages, and errors in the terminal.
+Starts a chat session with a running oracle over SSE — renders tool calls, assistant messages, and errors in the terminal. It's a flag, not a subcommand:
 
 ```sh
-qiforge-cli chat
+qiforge-cli --chat
 ```
 
-Interactive — prompts for the oracle URL (or uses the saved one from `--init` / `new`).
+Interactive — prompts for the oracle URL (or uses the saved one from `new`).
 
 ## qiforge-cli logout
 
@@ -271,18 +265,22 @@ qiforge-cli logout
 
 Clears stored authentication. Future commands prompt for auth again.
 
-## What `--init` writes
+## What `qiforge-cli new` writes
 
 ```text
-your-oracle-project/
-├── oracle.config.json          # Oracle config (name, model, prompt, entityDid, …)
-├── apps/
-│   └── app/
-│       ├── .env                # Tier-0 vars + initial plugin vars
-│       ├── oracle.config.json  # Copy for Docker builds
-│       └── …
-├── packages/
-└── …
+my-oracle/
+├── src/
+│   ├── main.ts                 # calls createOracleApp({ config, plugins })
+│   ├── config.ts               # OracleConfig
+│   └── plugins/                # your plugins go here
+├── .claude/
+│   └── skills/qiforge-oracle/  # Claude Code skill (project-local)
+├── .env                        # Tier-0 vars + initial plugin vars
+├── oracle.config.json          # name, model, prompt, entityDid, …
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+└── CLAUDE.md                   # bootstrapping for Claude Code
 ```
 
 The CLI also scaffolds a **`qiforge-oracle` Claude Code skill** at `.claude/skills/qiforge-oracle/` so any AI agent you point at the project (Claude Code, Cursor, etc.) immediately has dense, scenario-specific guidance on the framework — adding plugins, adding tools, wiring env, writing tests with `createTestRuntime`, debugging boot. The skill is project-local: it ships inside every scaffolded oracle, no separate install needed. See the [skill source](https://github.com/ixoworld/ixo-oracles-cli/tree/main/src/templates/starter/.claude/skills/qiforge-oracle) in the CLI repo.
@@ -290,23 +288,30 @@ The CLI also scaffolds a **`qiforge-oracle` Claude Code skill** at `.claude/skil
 Generated `.env` skeleton:
 
 ```text
-PORT=4000
+PORT=3000
 ORACLE_NAME=your-oracle-name
+NETWORK=devnet
 
 MATRIX_BASE_URL=https://matrix.ixo.world
-MATRIX_ORACLE_ADMIN_ACCESS_TOKEN=...
-MATRIX_ORACLE_ADMIN_PASSWORD=...
 MATRIX_ORACLE_ADMIN_USER_ID=...
+MATRIX_ORACLE_ADMIN_PASSWORD=...
+MATRIX_ORACLE_ADMIN_ACCESS_TOKEN=...
+MATRIX_ACCOUNT_ROOM_ID=...
+MATRIX_VALUE_PIN=...
+MATRIX_RECOVERY_PHRASE=...
 
+BLOCKSYNC_GRAPHQL_URL=https://devnet-blocksync-graphql.ixo.earth/graphql
+RPC_URL=https://devnet.ixo.earth/rpc/
+ORACLE_DID=did:ixo:ixo1...
+ORACLE_ENTITY_DID=did:ixo:entity:...
+SECP_MNEMONIC=...
+SQLITE_DATABASE_PATH=./.data/sqlite
+
+LLM_PROVIDER=openrouter
 OPEN_ROUTER_API_KEY=
+
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=
-
-ORACLE_ADDRESS=...
-ORACLE_DID=...
-ORACLE_MNEMONIC=...
-MATRIX_VAULT_PIN=...
-ENTITY_DID=...
 ```
 
 Fill in the plugin-specific vars before booting.

--- a/build-an-oracle/reference/client-sdk.mdx
+++ b/build-an-oracle/reference/client-sdk.mdx
@@ -9,9 +9,9 @@ icon: "react"
 `@ixo/oracles-client-sdk` is the official React client for a QiForge oracle. It wraps:
 
 - The streaming chat endpoint over SSE.
-- The WebSocket event channel (tool calls, render components, browser tools, reasoning, AG-UI actions).
-- UCAN delegation handling (refreshing Matrix access tokens, signing).
-- Browser-side tool registration (so the agent can call DOM/UI actions on the user's tab).
+- The WebSocket event channel (tool calls, render components, browser tools, AG-UI actions).
+- UCAN auth — signing invocations (authentication) and delegations (downstream authorization).
+- Browser-side tools and AG-UI actions (so the agent can act on the user's tab / UI).
 
 If you're building a Portal-like web UI for your oracle, use this. If you're building a non-React client (CLI, mobile app), implement the HTTP/WS protocol directly — the API reference is [API endpoints](/build-an-oracle/reference/api-endpoints).
 
@@ -21,86 +21,219 @@ If you're building a Portal-like web UI for your oracle, use this. If you're bui
 pnpm add @ixo/oracles-client-sdk
 ```
 
-## useChat
+`react >= 18` and `zod ^3` are peer dependencies.
 
-The primary hook. Provides the message thread, the send function, and the SSE/WS event stream.
+## OraclesProvider (required wrapper)
+
+Every hook calls `useOraclesContext()`, which throws `useOraclesContext must be used within a OraclesProvider` if there's no provider above it. Wrap your app once. The provider holds the wallet, signs transactions, and turns your `createDelegation` / `createInvocation` callbacks into the cached auth artifacts the hooks attach to requests.
 
 ```tsx
-import { useChat } from '@ixo/oracles-client-sdk';
+import { OraclesProvider } from '@ixo/oracles-client-sdk';
 
-function Chat({ oracleUrl, sessionId, ucanDelegation, userDid }) {
-  const { messages, sendMessage, isStreaming, events } = useChat({
-    oracleUrl,
+function Root({ children }) {
+  return (
+    <OraclesProvider
+      initialWallet={{
+        address: 'ixo1...',
+        did: 'did:ixo:ixo1...',
+        matrix: { accessToken: 'syt_...', homeServer: 'https://matrix.ixo.world' },
+      }}
+      transactSignX={async (messages, memo) => {
+        // sign + broadcast the chain tx with your wallet; return the result
+        return undefined;
+      }}
+      createDelegation={async (oracleDid) => {
+        // sign a user→oracle UCAN delegation (downstream authorization)
+        return { serialized: '<base64-car>', expiresAt: Date.now() + 60 * 60 * 1000 };
+      }}
+      createInvocation={async (oracleDid) => {
+        // sign a short-lived UCAN invocation (primary authentication)
+        return { serialized: '<base64-car>', expiresAt: Date.now() + 15 * 60 * 1000 };
+      }}
+    >
+      {children}
+    </OraclesProvider>
+  );
+}
+```
+
+<ParamField path="initialWallet" type="{ address, did, matrix: { accessToken, homeServer } }" required>
+  The connected user's wallet + Matrix session. Required.
+</ParamField>
+<ParamField path="transactSignX" type="(messages, memo?) => Promise<unknown>" required>
+  Signs and broadcasts chain transactions (e.g. paying to contract the oracle).
+</ParamField>
+<ParamField path="createDelegation" type="(oracleDid: string) => Promise<{ serialized: string; expiresAt: number }>" required>
+  Mints a user→oracle UCAN delegation. The provider caches it and sends it as `x-ucan-delegation`.
+</ParamField>
+<ParamField path="createInvocation" type="(oracleDid: string) => Promise<{ serialized: string; expiresAt: number }>">
+  Optional (migration-safe). Mints a short-lived UCAN invocation; the provider sends it as `Authorization: Bearer …` + `X-Auth-Type: ucan` (primary auth). Omit to stay on delegation-only auth.
+</ParamField>
+
+## useChat
+
+The primary hook. Provides the message thread, the send function, and live streaming state.
+
+```tsx
+import { useChat, useOracleSessions, renderMessageContent } from '@ixo/oracles-client-sdk';
+
+function Chat({ oracleDid }: { oracleDid: string }) {
+  const { sessions, createSession } = useOracleSessions(oracleDid);
+  const sessionId = sessions?.[0]?.sessionId ?? '';
+
+  const { messages, sendMessage, isSending, status } = useChat({
+    oracleDid,
     sessionId,
-    headers: {
-      'x-ucan-delegation': ucanDelegation,
-      'x-did': userDid,
+    onPaymentRequiredError: (claimIds) => {
+      // the oracle needs payment before answering — surface a paywall
+      console.log('Payment required:', claimIds);
     },
   });
 
   return (
     <div>
-      {messages.map((m) => <Message key={m.id} message={m} />)}
-      <Input onSubmit={sendMessage} disabled={isStreaming} />
+      <button onClick={() => createSession()}>New chat</button>
+      {messages.map((m) => (
+        <div key={m.id} className={m.type}>{renderMessageContent(m.content)}</div>
+      ))}
+      <form onSubmit={(e) => { e.preventDefault(); sendMessage(e.currentTarget.message.value); }}>
+        <input name="message" />
+        <button type="submit" disabled={isSending}>
+          {status === 'streaming' ? 'Streaming…' : 'Send'}
+        </button>
+      </form>
     </div>
   );
 }
 ```
 
-The returned values:
+Options (`IChatOptions`):
 
-- **`messages`** — current thread history, including pending streamed tokens.
-- **`sendMessage(text)`** — submit a user message. Triggers a streaming response.
-- **`isStreaming`** — `true` while the agent is generating.
-- **`events`** — typed event stream (tool calls, render components, browser tool calls, reasoning, …).
+<ParamField path="oracleDid" type="string" required>
+  The oracle's DID. The SDK resolves its API/WS URL from the oracle's on-chain config.
+</ParamField>
+<ParamField path="sessionId" type="string" required>
+  The chat session to read/write. Create one with `useOracleSessions().createSession()`.
+</ParamField>
+<ParamField path="onPaymentRequiredError" type="(claimIds: string[]) => void" required>
+  Called when the oracle returns a payment-required error. Surface a paywall.
+</ParamField>
+<ParamField path="browserTools" type="Record<string, { toolName, description, schema, fn }>">
+  Browser-side tools the agent may call on the user's tab (see below).
+</ParamField>
+<ParamField path="uiComponents" type="UIComponents">
+  Map of render-component name → React component for `render_component` events.
+</ParamField>
+<ParamField path="overrides" type="{ baseUrl?, wsUrl? }">
+  Override the resolved API / WebSocket URLs (local dev, self-host).
+</ParamField>
+<ParamField path="streamingMode" type="'batched' | 'immediate'">
+  How streamed tokens are flushed to state.
+</ParamField>
+
+Returned values:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `messages` | `IMessage[]` | Thread history, including in-flight streamed content. |
+| `sendMessage` | `(message: string) => void` | Submit a user message. |
+| `abortStream` | `() => Promise<void>` | Abort the in-flight response. |
+| `status` | `'submitted' \| 'streaming' \| 'ready' \| 'error'` | Current chat state. |
+| `isSending` | `boolean` | `true` while submitting or streaming. |
+| `isLoading` | `boolean` | Initial history fetch in flight. |
+| `error` / `sendMessageError` | `Error \| undefined` | Load error / send error. |
+| `refetchMessages` | `() => Promise<…>` | Re-pull the thread from the server. |
+| `isRealTimeConnected` | `boolean` | WebSocket connection status. |
+| `isConfigReady` | `boolean` | The oracle's config has resolved. |
+
+There is no `isStreaming` or `events` field — use `status` / `isSending` for streaming state.
 
 ## Browser tools
 
-Browser tools let the agent call DOM/UI actions on the user's tab. Register them once on mount:
+Browser tools let the agent call DOM/UI actions on the user's tab. Pass them as the `browserTools` option to `useChat` — a map keyed by tool name. The SDK advertises them to the agent, forwards each call to your `fn`, and returns the result over the WebSocket.
 
 ```tsx
-import { registerBrowserTools } from '@ixo/oracles-client-sdk';
+import { useChat } from '@ixo/oracles-client-sdk';
+import { z } from 'zod';
 
-useEffect(() => {
-  registerBrowserTools([
-    {
-      name: 'open_portal_route',
-      description: 'Navigate to a route inside the Portal.',
-      schema: z.object({ route: z.string() }),
-      handler: async ({ route }) => {
-        router.push(route);
-        return { ok: true };
-      },
+const browserTools = {
+  open_portal_route: {
+    toolName: 'open_portal_route',
+    description: 'Navigate to a route inside the Portal.',
+    schema: z.object({ route: z.string() }),
+    fn: async ({ route }: { route: string }) => {
+      router.push(route);
+      return { ok: true };
     },
-  ]);
-}, []);
+  },
+};
+
+const { messages, sendMessage } = useChat({
+  oracleDid,
+  sessionId,
+  onPaymentRequiredError: () => {},
+  browserTools,
+});
 ```
 
-The SDK forwards browser tool calls from the agent to your registered handlers and returns the results back through the WebSocket. The Portal plugin's sub-agent only constructs when `state.browserTools` is non-empty (declared via registration).
+There is no `registerBrowserTools` export — browser tools are the `browserTools` option above.
 
-## Events you can render
+## AG-UI actions
 
-| Event | What you render |
+`useAgAction` registers an agent-invokable action with an optional render. The provider tracks registered actions; `useChat` advertises them and renders their output inline.
+
+```tsx
+import { useAgAction } from '@ixo/oracles-client-sdk';
+import { z } from 'zod';
+
+useAgAction({
+  name: 'create_data_table',
+  description: 'Render a data table from structured rows.',
+  parameters: z.object({
+    title: z.string().optional(),
+    columns: z.array(z.any()),
+    data: z.array(z.any()),
+  }),
+  handler: async ({ data }) => ({ ok: true, rowCount: data.length }),
+  render: ({ status, args }) =>
+    status === 'done' && args ? <DataTable {...args} /> : null,
+});
+```
+
+## Events
+
+Streamed and WebSocket events are surfaced as the typed `AnyEvent` union and rendered through `renderMessageContent` / your `uiComponents` map. The event `eventName` values match the wire names:
+
+| `eventName` | What it carries |
 | --- | --- |
-| `toolCall` | "Agent called `<tool>`" with args/result. |
-| `actionCall` | An AG-UI action invocation. |
-| `renderComponent` | A structured UI component the agent wants displayed (table, chart, form). |
-| `reasoning` | Intermediate reasoning text the agent emitted. |
-| `browserToolCall` | A tool call to a browser-side tool you registered. |
-| `router` | Routing decision between agents/sub-agents. |
-| `messageCacheInvalidation` | Hint to drop a cached message. |
+| `tool_call` | A tool invocation (and its result). |
+| `render_component` | A structured UI component the agent wants displayed. |
+| `browser_tool_call` | A call to one of your `browserTools`. |
 
-The SDK exposes typed event objects; you decide how to render them.
+The full server/client WebSocket event catalog is in [API endpoints → WebSocket](/build-an-oracle/reference/api-endpoints#websocket).
+
+## Other exports
+
+| Export | Purpose |
+| --- | --- |
+| `useOracleSessions(oracleDid)` | Create, list, and delete chat sessions. |
+| `useOraclesConfig(oracleDid)` | The oracle's resolved public config (API URL, model, price). |
+| `useContractOracle()` | Pay to contract (subscribe to) an oracle. |
+| `useMemoryEngine()` | Read/write the optional persistent memory engine. |
+| `useGetOpenIdToken()` / `getOpenIdToken()` | Mint a Matrix OpenID token for the user. |
+| `renderMessageContent(content)` | Turn stored message content into React nodes. |
+| `OraclesProvider`, `useOraclesContext` | The provider + its context accessor. |
+| `@ixo/oracles-client-sdk/live-agent` → `useLiveAgent` | Encrypted voice/video live-agent calls (separate entry point). |
 
 ## Auth lifecycle
 
-The SDK handles:
+The provider owns auth. From your `createDelegation` / `createInvocation` callbacks it:
 
-- Refreshing the Matrix access token before it expires.
-- Signing UCAN delegations from the user's session key.
-- Re-establishing the WebSocket on reconnect.
+- Caches the signed delegation and invocation per `(userDid, oracleDid)`.
+- Attaches `Authorization: Bearer <invocation>` + `X-Auth-Type: ucan` (primary) and `x-ucan-delegation` (downstream / fallback) to every request.
+- Passes the same artifacts on the WebSocket handshake (`auth.invocation` / `auth.ucanDelegation`).
 
-Provide a `getDelegation()` function that returns a fresh UCAN delegation when called — the SDK calls it on connect and on reconnect.
+When a stored delegation is missing or expired, the oracle nudges the user to re-authorize; your app calls `createDelegation` again to mint a fresh one (the client-sdk POSTs it to [`/delegation`](/build-an-oracle/reference/api-endpoints#delegation-delegation)).
 
 ## Where to read next
 

--- a/build-an-oracle/reference/createoracleapp.mdx
+++ b/build-an-oracle/reference/createoracleapp.mdx
@@ -48,11 +48,12 @@ export interface CreateOracleAppOptions {
         opening: '...',
         communicationStyle: '...',
         capabilities: '...',
+        customInstructions: '...',
       },
     }
     ```
 
-    **prompt sub-fields** — all three are optional. Omit any you don't need.
+    **prompt sub-fields** — all four are optional. Omit any you don't need.
 
     **`opening`**
 
@@ -76,6 +77,20 @@ export interface CreateOracleAppOptions {
     Rendered **above** the Tier-1 plugin capability block (the auto-generated list of `visibility='always'` plugins). No header is added by the runtime around this text — write your own heading if you want one. If empty or absent, the field is omitted entirely.
 
     Use this to describe high-level skills the oracle has that aren't obvious from the plugin manifest alone — things like domain expertise, supported workflows, or what the agent should proactively offer.
+
+    **`customInstructions`**
+
+    Free-form standing guidance injected **verbatim** into a dedicated `## Custom Instructions` section of the system prompt. Use it for house style, domain rules, compliance guardrails, or any directive that doesn't fit `communicationStyle` (tone) or `capabilities` (the elevator pitch). The runtime renders the section only when there is content.
+
+    Operating guides contributed by on-demand capabilities the agent loads mid-thread (e.g. the Flow Builder guide, which appears once `flows` is in `loadedPlugins`) are appended **after** your text in the same section — so they cost no tokens on turns where the capability is never loaded.
+
+    ```ts
+    prompt: {
+      customInstructions: `Always cite the registry document ID when quoting issuance data.
+    Never promise a delivery date you can't verify against the indexer.
+    Decline any request to move funds — you advise, you do not transact.`,
+    }
+    ```
 
     **`entityDid`**
 
@@ -101,6 +116,9 @@ export interface CreateOracleAppOptions {
     - Draft verification reports, CORSIAs letters, and board summaries.
     - Search and cite methodology documents from the oracle knowledge base.
     - Schedule follow-up reminders and track open action items across conversations.`,
+        customInstructions: `Always cite the registry document ID when quoting issuance data.
+    Treat any methodology version older than 18 months as "needs review" and flag it.
+    You advise on carbon projects — you never authorise transactions or move funds.`,
       },
     }
     ```
@@ -110,13 +128,13 @@ export interface CreateOracleAppOptions {
     - **Type:** `Partial<Record<BundledFeatureName | (string & {}), FeatureToggle>>` where `FeatureToggle = boolean | 'auto'`
     - **Required:** no
 
-    Override the default opt-in state per plugin. Keys are plugin names. Values: `true` (force on), `false` (force off), `'auto'` (run `autoDetect(env)`). Omitted keys are treated as `'auto'`.
+    Override the default opt-in state per plugin. Keys are plugin **names** — the kebab-case `name` field of each plugin (e.g. `'domain-indexer'`, `'user-preferences'`), not a camelCase alias. Values: `true` (force on), `false` (force off), `'auto'` (run `autoDetect(env)`). Omitted keys are treated as `'auto'`.
 
     ```ts
     features: {
       slack: false,
       composio: true,
-      domainIndexer: 'auto',
+      'domain-indexer': 'auto',
     }
     ```
   </Accordion>
@@ -126,6 +144,17 @@ export interface CreateOracleAppOptions {
     - **Required:** no
 
     Your plugin instances. Plus any bundled plugins you want to instantiate with constructor args (`new EditorPlugin({ matrixClient })`, `new CreditsPlugin({ redis, network })`). The plugin loader dedupes by `name`, so an explicit instance overrides the bundled default of the same name.
+
+    ```ts
+    import { EditorPlugin, FlowsPlugin } from '@ixo/oracle-runtime';
+    import { WeatherPlugin } from './plugins/weather/index.js';
+
+    plugins: [
+      new EditorPlugin({ matrixClient }), // overrides the bundled editor
+      new FlowsPlugin({ matrixClient }),  // opt-in, not bundled
+      new WeatherPlugin(),                // your own plugin
+    ]
+    ```
   </Accordion>
 
   <Accordion title="nestModules" icon="server">
@@ -133,6 +162,15 @@ export interface CreateOracleAppOptions {
     - **Required:** no
 
     Your own NestJS modules. Spread into `RuntimeAppModule.imports`. They get full DI access to the Tier-0 services (Sessions, Messages, Secrets, UCAN, …) and can declare controllers, providers, `OnModuleInit`, `OnModuleDestroy`.
+
+    ```ts
+    @Module({ controllers: [VersionController] })
+    class VersionModule {}
+
+    nestModules: [VersionModule]
+    ```
+
+    Routes these modules expose still pass through `AuthHeaderMiddleware` unless you list them in `authExcludedRoutes`.
   </Accordion>
 
   <Accordion title="authExcludedRoutes" icon="globe">
@@ -155,13 +193,23 @@ export interface CreateOracleAppOptions {
     - **Required:** no
 
     Override the bundled plugin set. Provided primarily for tests so the harness can spin up `createOracleApp` without dragging in the full bundled catalog. Production callers should leave this unset.
+
+    ```ts
+    // test only — boot with a single plugin instead of the full catalog
+    bundledPlugins: [new MemoryPlugin()]
+    ```
   </Accordion>
 
   <Accordion title="env" icon="file-lines">
     - **Type:** `NodeJS.ProcessEnv`
     - **Required:** no
 
-    Override `process.env`. Tests use this to inject a clean env. Production code should leave it unset.
+    Override `process.env`. Tests use this to inject a clean, controlled env so the boot doesn't depend on the machine's environment. Production code should leave it unset.
+
+    ```ts
+    // test only — inject a controlled env instead of process.env
+    env: { ...baseTestEnv, LLM_PROVIDER: 'nebius' }
+    ```
   </Accordion>
 
   <Accordion title="skipMatrixInit" icon="circle-pause">
@@ -169,6 +217,11 @@ export interface CreateOracleAppOptions {
     - **Required:** no
 
     Skip starting the Matrix background init. Tests set this so the factory resolves without touching real Matrix. Do not use in production.
+
+    ```ts
+    // test only
+    skipMatrixInit: true
+    ```
   </Accordion>
 
   <Accordion title="skipGracefulShutdown" icon="circle-pause">
@@ -176,22 +229,144 @@ export interface CreateOracleAppOptions {
     - **Required:** no
 
     Skip registering the SIGTERM/SIGINT shutdown handler. Tests set this so the harness does not leak process-level listeners. Do not use in production.
+
+    ```ts
+    // test only
+    skipGracefulShutdown: true
+    ```
   </Accordion>
 
   <Accordion title="logger" icon="scroll">
     - **Type:** `Logger`
     - **Required:** no
 
-    Override the bootstrap logger. Falls back to NestJS `Logger`.
+    Override the bootstrap logger — any object implementing the `Logger` interface (`log`, `error`, `warn`, optional `debug`/`verbose`/`child`). Falls back to NestJS `Logger`.
+
+    ```ts
+    import { Logger } from '@nestjs/common';
+
+    logger: new Logger('MyOracle')
+    ```
   </Accordion>
 
   <Accordion title="hooks" icon="link">
     - **Type:** `MainAgentHooks`
     - **Required:** no
 
-    Optional overrides for the agent-build hooks (checkpointer, model resolver, prompt section snippets). Merged on top of the runtime's defaults — host hooks win. The runtime supplies a per-user SQLite checkpointer by default; pass `{ checkpointerForUser: ... }` here to swap it for an alternate implementation.
+    Overrides for the agent build — the chat model (`resolveModel`), the per-user checkpointer (`checkpointerForUser`), and the prompt/middleware toggles. Merged on top of the runtime's defaults, and **host hooks win**.
+
+    This is where you **change the AI model**. See [MainAgentHooks](#mainagenthooks) below for all ten fields, the `resolveModel` example, and the `'main'`-only nuance.
+
+    ```ts
+    import { getProviderChatModel } from '@ixo/oracle-runtime';
+
+    hooks: {
+      resolveModel: (role, params) =>
+        getProviderChatModel(role, {
+          ...params,
+          ...(role === 'main' && { model: 'google/gemini-3.1-flash-lite' }),
+        }),
+    }
+    ```
   </Accordion>
 </AccordionGroup>
+
+## MainAgentHooks
+
+`hooks` lets you override how the runtime builds the main agent on every request, without forking the runtime. The runtime merges your hooks over its own defaults — **your hooks win** (`{ ...defaultHooks, ...opts.hooks }`). The only default the runtime sets is `checkpointerForUser` (a per-user SQLite store); everything else is unset unless you provide it.
+
+```ts
+import type { MainAgentHooks } from '@ixo/oracle-runtime';
+```
+
+### Change the AI model
+
+This is the answer to "how do I change the model?". `resolveModel` is the model resolver. Return any LangChain `BaseChatModel` for the given role:
+
+```ts
+import { createOracleApp, getProviderChatModel } from '@ixo/oracle-runtime';
+
+const app = await createOracleApp({
+  config,
+  plugins,
+  hooks: {
+    // role is 'main' | 'subagent' | 'utility' | (string & {}).
+    // Spreading `params` preserves the provider's fallback models + latency sort.
+    resolveModel: (role, params) =>
+      getProviderChatModel(role, {
+        ...params,
+        ...(role === 'main' && { model: 'google/gemini-3.1-flash-lite' }),
+      }),
+  },
+});
+```
+
+<Warning>
+  **The runtime only ever calls `resolveModel('main')`.** Sub-agent, utility, vision and guard models are resolved separately, straight through the provider config (`ambient.llm.get(role)` → `getProviderChatModel`). So a `resolveModel` hook changes **only the main agent's model** unless your own plugin code also routes its roles through the hook. Branch on `role === 'main'` (as above) so you don't accidentally rewrite a role you never see.
+</Warning>
+
+<Note>
+  **Where model IDs come from.** Each role (`main`, `subagent`, `vision`, `guard`, …) maps to a hardcoded model ID per provider. The provider is chosen by env: `LLM_PROVIDER` = `openrouter` (default) or `nebius`, with the matching key (`OPEN_ROUTER_API_KEY` / `NEBIUS_API_KEY`). There is **no env var to change the main model ID** — overriding it is exactly what `resolveModel` is for. Building the model with `getProviderChatModel` (rather than `new ChatOpenAI(...)`) keeps the OpenRouter fallback-models list and latency sort the `'main'` role ships with.
+</Note>
+
+Prefer a different SDK model? Return your own LangChain model instead — but you lose the provider's fallback/latency wiring, so you own retries and outages:
+
+```ts
+import { ChatOpenAI } from '@langchain/openai'; // add this dependency yourself
+
+hooks: {
+  resolveModel: () => new ChatOpenAI({ model: 'gpt-4o' }),
+}
+```
+
+### All ten fields
+
+| Field | Type | What it does |
+| --- | --- | --- |
+| `resolveModel` | `(role: ModelRole, params?: ChatOpenAIFields) => BaseChatModel` | Resolves the chat model. Called once, with `'main'`. Default: `ambient.llm.get('main')`. |
+| `checkpointerForUser` | `(userDid: string) => Promise<BaseCheckpointSaver>` | Per-user conversation store. Default: per-user SQLite synced to Matrix — override to swap the backend. |
+| `getRoomTitle` | `(roomId: string) => Promise<string \| undefined>` | Page-title lookup. **Providing it adds the page-context middleware** to the stack; omitting it leaves that middleware out. |
+| `safetyModel` | `BaseChatModel` | Cheap classifier model. **Providing it adds the safety-guardrail middleware**; omitting it leaves it out. |
+| `validationSkipToolNames` | `string[]` | Tool names whose dangling `ToolMessage` outputs are stripped before the next model call — typically sub-agent tools whose output the caller summarises, not the model. |
+| `operationalMode` | `string` | Replaces the default operational-mode prompt block. (The editor plugin's per-page mode still overrides this when a page is open.) |
+| `editorSection` | `string` | Editor prompt block — normally populated by the editor plugin; set it only if you compose the section yourself. |
+| `composioContext` | `string` | Composio guidance prompt block — normally populated by the composio plugin. |
+| `userSecretsContext` | `string` | Per-key secret bullet list rendered into the prompt (e.g. `- _USER_SECRET_FOO`). |
+| `degradedServicesBlock` | `string` | A "some services are degraded" notice appended to the system prompt body. |
+
+`ModelRole` is `'main' | 'subagent' | 'utility' | (string & {})`. `ChatOpenAIFields` is `Record<string, unknown>` — the optional fields forwarded to the underlying chat model.
+
+**Swap the checkpointer** — supply your own LangGraph saver per user:
+
+```ts
+import type { BaseCheckpointSaver } from '@langchain/langgraph';
+
+hooks: {
+  checkpointerForUser: async (userDid: string): Promise<BaseCheckpointSaver> => {
+    return myStore.saverFor(userDid);
+  },
+}
+```
+
+**Turn on the conditional middlewares** — both are added to the stack only when their hook is present:
+
+```ts
+hooks: {
+  // adds the page-context middleware
+  getRoomTitle: async (roomId) => myRoomTitles.get(roomId),
+  // adds the safety-guardrail middleware
+  safetyModel: getProviderChatModel('guard'),
+}
+```
+
+**Prompt blocks** — the string fields are appended to dedicated prompt sections. Most are populated by their owning plugin; set them only when you're driving the section yourself:
+
+```ts
+hooks: {
+  operationalMode: 'You are operating in read-only audit mode. Never call mutating tools.',
+  validationSkipToolNames: ['call_research_agent'],
+}
+```
 
 ## OracleApp
 
@@ -249,7 +424,7 @@ export interface OracleApp {
   </Accordion>
 
   <Accordion title="listen(port?)" icon="play">
-    Start the HTTP server. Honours `beforeListen` callbacks first. Port resolution: explicit `port` arg → `PORT` env (validated) → `5678` default. Throws if called twice.
+    Start the HTTP server. Honours `beforeListen` callbacks first. Port resolution: explicit `port` arg → `PORT` env (validated, defaults to **3000**). Throws if called twice.
   </Accordion>
 </AccordionGroup>
 
@@ -266,7 +441,11 @@ The function executes these steps in order:
 7. Builds the internal `OracleIdentity` from `config` + validated env.
 8. Populates the six registries (tools, sub-agents, middleware, manifests, configSchema, sharedState).
 9. Collects `getNestModules` from every loaded plugin.
-10. Builds the dynamic `RuntimeAppModule` and bootstraps NestJS (`NestFactory.create`). CORS enabled with the framework's allowed headers. Swagger UI mounts at `/docs`.
+10. Builds the dynamic `RuntimeAppModule` and bootstraps NestJS (`NestFactory.create`). Installs a global `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true })`, enables CORS with the framework's allowed headers (`authorization`, `x-auth-type`, `x-ucan-delegation`, …), and mounts Swagger UI at `/docs`.
+
+   <Note>
+     The global `ValidationPipe` applies to **every** controller — including ones you add via `nestModules` or a plugin's `getNestModules`. Annotate request DTOs with `class-validator` decorators: unknown body fields are rejected (`forbidNonWhitelisted`), unannotated props are stripped (`whitelist`), and nested DTOs are instantiated (`transform`). A controller that silently 400s on an extra field is hitting this pipe.
+   </Note>
 11. Builds `AmbientServices`.
 12. Warms the boot caches (each registry runs its boot-time hooks once).
 13. Wires the default checkpointer (`UserMatrixSqliteSyncService` + `SqliteSaver`), then merges host `hooks` over it.

--- a/build-an-oracle/reference/environment-variables.mdx
+++ b/build-an-oracle/reference/environment-variables.mdx
@@ -48,10 +48,19 @@ Always required by the runtime. Source: `packages/oracle-runtime/src/config/base
 | Variable | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `BLOCKSYNC_GRAPHQL_URL` | string | — | Required. |
-| `ORACLE_DID` | string | — | Required. The oracle's own DID (`did:ixo:ixo1...`) used as signer identity. |
-| `ORACLE_ENTITY_DID` | string | — | Required. The oracle's on-chain entity record. |
+| `ORACLE_DID` | string | — | Required. The oracle's own DID (`did:ixo:ixo1...`) — the signer identity used by the UCAN service and the auth middleware. |
+| `ORACLE_ENTITY_DID` | string | — | Required. The oracle's on-chain entity record DID. Distinct from `ORACLE_DID` — do not conflate them. |
 | `SECP_MNEMONIC` | string | — | Required. |
 | `RPC_URL` | string | — | Required. |
+
+### Auth / UCAN
+
+Always present. Both are `z.coerce.number()` — set them as plain integer strings in `.env`.
+
+| Variable | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `UCAN_AUTH_MAX_TTL_SECONDS` | number (coerced) | `900` | Max lifetime (seconds) the oracle accepts for a user **auth invocation**. Bounds the server-side replay window regardless of the TTL the client declares. Default 15 minutes. |
+| `UCAN_REAUTH_PROMPT_THROTTLE_SECONDS` | number (coerced) | `21600` | Throttle window (seconds) between "please re-authorize" prompts posted into a user's Matrix room when their stored delegation is missing or expired. Default 6 hours. |
 
 ### LLM
 
@@ -62,7 +71,7 @@ Always required by the runtime. Source: `packages/oracle-runtime/src/config/base
 | `OPEN_ROUTER_API_KEY` | string | — | Required if `LLM_PROVIDER=openrouter`. |
 | `NEBIUS_API_KEY` | string | — | Required if `LLM_PROVIDER=nebius`. |
 
-Cross-field: the API key for the selected `LLM_PROVIDER` must be present; otherwise boot fails with a named-field error.
+Cross-field check (`validateLlmProviderKey`): the API key for the selected `LLM_PROVIDER` must be present — `OPEN_ROUTER_API_KEY` when `LLM_PROVIDER=openrouter` (the default), `NEBIUS_API_KEY` when `LLM_PROVIDER=nebius`. A missing key fails boot with a named-field error (e.g. `OPEN_ROUTER_API_KEY` / `NEBIUS_API_KEY`) rather than a generic upstream 401 at request time. The per-role model ids are hardcoded per provider — there is no env var to swap the main model id (use the `resolveModel` hook for that).
 
 ### Misc
 
@@ -80,7 +89,7 @@ Cross-field: the API key for the selected `LLM_PROVIDER` must be present; otherw
 | `LANGSMITH_PROJECT` | string | — | |
 | `LANGSMITH_ENDPOINT` | string | — | Optional override of the LangSmith API URL. |
 
-Declared in the base schema so they show up in `qiforge env` output. LangChain auto-wires when these are present in `process.env`; the runtime never reads them directly.
+Declared in the base schema so they show up in `qiforge-cli env` output. LangChain auto-wires when these are present in `process.env`; the runtime never reads them directly.
 
 ## Per-plugin
 
@@ -95,7 +104,7 @@ Only required when the named plugin is loaded.
 | `composio` | `COMPOSIO_API_KEY` | Yes (when loaded) | |
 | `composio` | `COMPOSIO_BASE_URL` | No | Defaults to `https://composio.ixo.earth`. |
 | `sandbox` | `SANDBOX_MCP_URL` | Yes | Must be a valid URL. |
-| `skills` | `SKILLS_CAPSULES_BASE_URL` | No | Defaults to bundled URL. |
+| `skills` | `SKILLS_CAPSULES_BASE_URL` | No | URL. Defaults to `https://capsules.skills.ixo.earth`. |
 | `slack` | `SLACK_BOT_OAUTH_TOKEN` | Yes | Triggers autoDetect. |
 | `slack` | `SLACK_APP_TOKEN` | No | |
 | `slack` | `SLACK_USE_SOCKET_MODE` | No | Defaults to `'true'`. |
@@ -103,8 +112,15 @@ Only required when the named plugin is loaded.
 | `slack` | `SLACK_RECONNECT_DELAY_MS` | No | Coerced to number; default `1000`. |
 | `credits` | `SUBSCRIPTION_URL` | No | URL. |
 | `credits` | `SUBSCRIPTION_ORACLE_MCP_URL` | No | URL. |
-| `credits` | `DISABLE_CREDITS` | No | Set to `'true'` to skip the plugin. |
+| `credits` | `DISABLE_CREDITS` | No | Enum — exactly `'true'` or `'false'` (any other value fails env validation). `'true'` disables the credit-enforcement middleware; the plugin's `autoDetect` also excludes the whole plugin when `DISABLE_CREDITS=true`. |
 | `tasks` | `REDIS_URL` | Yes (when loaded) | Triggers autoDetect. |
+| `tasks` | `TASKS_MAX_PER_USER` | No | Coerced positive int; default `50`. Max scheduled tasks per user. |
+| `tasks` | `TASKS_RUN_LOCK_TTL_SEC` | No | Coerced positive int; default `600`. Per-run lock TTL (seconds). |
+| `tasks` | `TASKS_MIN_CRON_INTERVAL_SEC` | No | Coerced positive int; default `300`. Minimum allowed cron interval (seconds). |
+| `matrix-group-chats` | `CHANNEL_MEMORY_SYNC_INTERVAL_MS` | No | Coerced int, min `1000`; default `60000`. Debounce window between a write and the Matrix snapshot upload. |
+| `matrix-group-chats` | `GROUP_CHAT_ACTIVE_THREAD_TTL_MS` | No | Coerced int, min `60000`; default `1800000`. How long a thread stays "active with the bot" after a reply. |
+| `matrix-group-chats` | `GROUP_CHAT_REQUIRE_POWER_LEVEL` | No | Coerced int, min `0`; default `0`. Extra minimum power level the bot must have before posting (`0` = use the room default). |
+| `matrix-group-chats` | `GROUP_CHAT_ROOM_INFO_TTL_MS` | No | Coerced int, min `60000`; default `1800000`. How long roomInfo (membership, DM flag) stays cached. |
 
 ## Variables read but not owned
 
@@ -118,7 +134,7 @@ These are declared in the plugin's sibling schemas (typed `optional()`); a missi
 
 ## Generating an `.env` template
 
-`qiforge env` (ships with TASK-33) generates a `.env` template for your installed plugin set. Until that lands, write the file by hand using this reference.
+`qiforge-cli env` generates a `.env` template for your installed plugin set. Until that lands, write the file by hand using this reference.
 
 ## Related references
 

--- a/build-an-oracle/reference/glossary.mdx
+++ b/build-an-oracle/reference/glossary.mdx
@@ -12,7 +12,7 @@ icon: "book"
 
 **`autoDetect`** — predicate `(env) => boolean` a plugin implements to opt itself in or out based on `process.env`. Runs when `features` doesn't explicitly set the toggle. See [Using bundled plugins](/build-an-oracle/develop/enable-bundled-plugins).
 
-**Bundled plugin** — a plugin shipped inside `@ixo/oracle-runtime` (one of 14). Loaded from `BUNDLED_PLUGINS` by default. See [Plugin catalog](/build-an-oracle/reference/bundled-plugins/overview).
+**Bundled plugin** — a plugin shipped inside `@ixo/oracle-runtime` (one of 15). Loaded from `BUNDLED_PLUGINS` by default. See [Plugin catalog](/build-an-oracle/reference/bundled-plugins/overview).
 
 **Checkpointer** — per-user SQLite saver (`UserMatrixSqliteSyncService` + `SqliteSaver`) that persists graph state across turns. Synced to Matrix in the background. See [State schema](/build-an-oracle/reference/state-schema).
 
@@ -50,7 +50,7 @@ icon: "book"
 
 **Meta-tool** — a built-in tool the runtime registers on every agent, not authored by any plugin. There are two: `list_capabilities` and `load_capability`. See [Meta-tools](/build-an-oracle/understand/meta-tools-and-loading).
 
-**Middleware** — LangChain `AgentMiddleware`. Hooks: `beforeModel`, `afterModel`, `onError`. Four are always-on (tool validation, retry, page context, safety guardrail); plugins add more via `getMiddlewares`. See [Plugin middleware](/build-an-oracle/develop/plugin-recipes/add-a-middleware).
+**Middleware** — LangChain `AgentMiddleware`. Hooks: `beforeAgent`, `beforeModel`, `wrapModelCall`, `wrapToolCall`, `afterModel`, `afterAgent` (there is no `onError` middleware hook — to handle errors, wrap a call in `wrapModelCall`/`wrapToolCall` with try/catch). Four are always-on, in order — capability gate, tool validation, tool-repetition guard, tool retry — plus two conditional: page context (when `hooks.getRoomTitle` is set) and safety guardrail (when `hooks.safetyModel` is set). Plugins add more via `getMiddlewares`. See [Plugin middleware](/build-an-oracle/develop/plugin-recipes/add-a-middleware).
 
 **NestJS module** — a unit of Nest DI (controllers, providers, lifecycle). Plugins ship modules via `getNestModules`; the host ships them via `createOracleApp({ nestModules })`.
 
@@ -82,6 +82,6 @@ icon: "book"
 
 **Topological sort** — the boot ordering pass over `dependsOn`. Plugins are loaded in dependency order; middleware fires in this order; tools are emitted in this order (for deterministic prompts).
 
-**UCAN** — User-Controlled Authorisation Network. The delegation envelope on every authenticated request (`x-ucan-delegation` header). The oracle mints downstream invocations signed by its `SECP_MNEMONIC`. See [Identity and auth](/build-an-oracle/develop/identity-and-auth).
+**UCAN** — User-Controlled Authorisation Network. Authentication is a user-signed UCAN *invocation* (`Authorization: Bearer …` + `X-Auth-Type: ucan`); authorization is the user→oracle *delegation* (`x-ucan-delegation`, also accepted as a migration-only auth fallback). The oracle mints downstream invocations signed by its `SECP_MNEMONIC`. See [Identity and auth](/build-an-oracle/develop/identity-and-auth).
 
 **Visibility** — one of `always`, `on-demand`, `silent`. Controls whether a plugin's tools are bound at boot, loaded on demand, or invisible to the agent. See [Visibility tiers](/build-an-oracle/develop/plugin-recipes/set-visibility).

--- a/build-an-oracle/reference/manifest-schema.mdx
+++ b/build-an-oracle/reference/manifest-schema.mdx
@@ -44,7 +44,7 @@ export interface ManifestExample {
     - **Type:** `string`
     - **Required:** yes
 
-    Human-readable name. Used to prefix every tool description (`[Climate Data] Fetch emissions…`) and appears in `qiforge inspect`. Distinct from `name` — `name` is kebab-case unique identifier, `title` is prose.
+    Human-readable name. Used to prefix every tool description (`[Climate Data] Fetch emissions…`) and appears in the `app.plugins.status()` report. Distinct from `name` — `name` is kebab-case unique identifier, `title` is prose.
   </Accordion>
 
   <Accordion title="summary" icon="quote-right">
@@ -74,6 +74,9 @@ export interface ManifestExample {
     - **Required:** no
 
     Anti-patterns. Use to disambiguate from other plugins.
+
+    **Validation:**
+    - Soft warn: > 4 entries, or any entry > 80 chars.
   </Accordion>
 
   <Accordion title="examples" icon="lightbulb">
@@ -83,7 +86,8 @@ export interface ManifestExample {
     Few-shot examples. Each example binds a user message to a tool call.
 
     **Validation:**
-    - Hard: every `example.tool` must reference a tool actually registered by this plugin.
+    - Hard: every `example.tool` must reference a tool the plugin actually registers — **but only when the plugin registers boot-time tools.** Plugins whose tools arrive at request time (MCP-sourced: `sandbox`, `memory`, `firecrawl`) register zero boot-time tools, so the cross-check is skipped for them. A sub-agent's wrapped name (`call_<name>`) is a valid example tool too.
+    - Soft warn: > 3 examples.
 
     ```ts
     examples: [
@@ -104,7 +108,7 @@ export interface ManifestExample {
     Labels for search and filter. Surfaced in `list_capabilities` output.
 
     **Validation:**
-    - Soft warn: any tag containing uppercase.
+    - Hard: every tag must be lowercase. An uppercase tag is a boot error — `createOracleApp` throws `Plugin manifest validation failed` and the oracle never starts (so `tags: ['Weather']` aborts boot; use `['weather']`).
   </Accordion>
 
   <Accordion title="category" icon="folder-tree">
@@ -121,9 +125,9 @@ export interface ManifestExample {
 
     Discovery and loading mode.
 
-    - `always` — tools bound at boot; listed in Tier-1 prompt.
-    - `on-demand` — tools NOT bound; manifest discoverable via `list_capabilities`; agent calls `load_capability` to make tools available.
-    - `silent` — invisible to agent; runs as middleware-only.
+    - `always` — tools bound at boot; the plugin is listed in the Tier-1 prompt block.
+    - `on-demand` — tools NOT bound at boot; the manifest is discoverable via `list_capabilities`; the agent calls `load_capability` to make the tools available.
+    - `silent` — the plugin is not advertised in the capability block or `list_capabilities`, but its tools still pass through the capability gate exactly like `always` and are visible to the model. `silent` means "unadvertised", **not** "hidden" or "secure" — it is not a security boundary.
 
     See [Visibility tiers](/build-an-oracle/develop/plugin-recipes/set-visibility).
   </Accordion>
@@ -169,13 +173,15 @@ Manifest validation runs before env validation, so manifest errors surface even 
 
 ## Cross-checking examples against tools
 
-Every `example.tool` is checked against the plugin's registered tool names. If a manifest references `tool: 'foo'` but the plugin doesn't register a tool named `foo`, boot fails:
+Each `example.tool` is checked against the names the plugin registers — the union of its boot-time tool names and its sub-agent wrapped names (`call_<name>`). If a manifest references `tool: 'foo'` but the plugin registers no such tool, boot fails:
 
 ```text
-[boot-error] Plugin 'weather' manifest example references unknown tool 'foo'.
+[boot-error] [weather] examples[0].tool: references unknown tool "foo".
 ```
 
 This catches typos and stale manifests during refactors.
+
+The check is **lenient for MCP-sourced plugins**: when a plugin registers no boot-time tools (its tools come from `getRequestTools` fetched per-request from an upstream MCP server — `sandbox`, `memory`, `firecrawl`), the runtime can't see those names at boot, so it skips the cross-check rather than false-flag every example.
 
 ## Worked example
 

--- a/build-an-oracle/reference/plugin-api.mdx
+++ b/build-an-oracle/reference/plugin-api.mdx
@@ -51,13 +51,13 @@ export abstract class OraclePlugin {
     - **Type:** `string`
     - **Convention:** kebab-case unique identifier.
 
-    Used by `features`, `dependsOn`, `softDependsOn`, `qiforge inspect`, the meta-tools. Boot fails on collision with another plugin's name.
+    Used by `features`, `dependsOn`, `softDependsOn`, the `app.plugins.status()` report, the meta-tools. Boot fails on collision with another plugin's name.
   </Accordion>
 
   <Accordion title="version" icon="code-branch">
     - **Type:** `string`
 
-    Plugin version. Surfaced in `qiforge inspect` output. Not used for compatibility checking in v1.
+    Plugin version. Surfaced in the `app.plugins.status()` report. Not used for compatibility checking in v1.
   </Accordion>
 
   <Accordion title="manifest" icon="scroll">
@@ -143,7 +143,16 @@ export abstract class OraclePlugin {
     getMiddlewares?(ctx: PluginContext): AgentMiddleware[];
     ```
 
-    LangChain `AgentMiddleware` instances inserted after the four always-on framework middleware (tool-validation, retry, page-context, safety-guardrail). Plugin middleware runs in topological dependency order across plugins.
+    LangChain `AgentMiddleware` instances appended to the stack after the framework's own middleware. Plugin middleware runs **last**, in topological dependency order across plugins.
+
+    The framework's four **always-on** middlewares, in order, are:
+
+    1. `capability-gate` — gates on-demand tools by the thread's `loadedPlugins`.
+    2. `tool-validation` — turns schema errors into recoverable `ToolMessage`s.
+    3. `tool-repetition-guard` — blocks identical repeated tool calls.
+    4. `tool-retry` — retries a failed tool call once.
+
+    Two more are **conditional** — added only when the matching `createOracleApp({ hooks })` field is set: `page-context` (when `hooks.getRoomTitle` is provided) and `safety-guardrail` (when `hooks.safetyModel` is provided). Both run before your plugin middleware.
   </Accordion>
 
   <Accordion title="getSharedState()" icon="share-nodes">

--- a/build-an-oracle/reference/plugin-context.mdx
+++ b/build-an-oracle/reference/plugin-context.mdx
@@ -6,7 +6,7 @@ icon: "layer-group"
 
 ## Overview
 
-`PluginContext` is what plugin code sees during request build. It's the input to `getTools`, `getSubAgents`, `getMiddlewares`, `getRequestTools`'s sibling `getTools`, and `getNestModules`.
+`PluginContext` is the boot-time context. It's the input to the boot-time hooks — `getTools`, `getSubAgents`, `getMiddlewares`, and `getNestModules`. (The request-time hooks `getRequestTools` / `getRequestSubAgents` receive the richer [`RuntimeContext`](/build-an-oracle/reference/runtime-context) instead.)
 
 ```ts
 export interface PluginContext<TConfig = MergedConfig> {
@@ -84,7 +84,7 @@ No authenticated user, no session, no live socket, no request data. If your code
 
 ## Lifetime
 
-A new `PluginContext` is built per request build. The runtime caches boot-time hook outputs (`getTools`, `getSubAgents`, `getMiddlewares`) — they fire once at boot for warming and once per request build for retrieval. Per-request-only data lives in `RuntimeContext`.
+Boot-time hooks (`getTools`, `getSubAgents`, `getMiddlewares`) fire **once** at boot, against a boot-warm `PluginContext`, and their output is **cached**. The per-request agent build reuses that cache and only re-runs the request-time hooks (`getRequestTools`, `getRequestSubAgents`) — so anything that varies per request must come from `RuntimeContext`, not `PluginContext`. `PluginContext` only ever carries boot-fixed data (`config`, `identity`, `availablePlugins`, `logger`).
 
 ## Related references
 

--- a/build-an-oracle/reference/runtime-context.mdx
+++ b/build-an-oracle/reference/runtime-context.mdx
@@ -43,6 +43,11 @@ export interface RuntimeContext<TConfig = MergedConfig> {
     getIndex: () => Promise<SecretIndex>;
     getValues: (keys: string[]) => Promise<Record<string, string>>;
   };
+  blobStore: {
+    put: (params: { userDid: string; name: string; value: string; ttlSeconds?: number }) => Promise<string>;
+    get: (params: { userDid: string; blobId: string }) => Promise<{ name: string; value: string } | null>;
+    isValidBlobId: (value: unknown) => value is string;
+  };
   matrix: {
     postToRoom: (roomId: string, content: unknown) => Promise<string>;
     getRoomState: (roomId: string) => Promise<RoomStateSnapshot>;
@@ -53,6 +58,13 @@ export interface RuntimeContext<TConfig = MergedConfig> {
     hasCapability: (resource: string, action: string) => boolean;
     mintInvocation: (target: { did: string; capability: string }, opts?: { skipCache?: boolean }) => Promise<string>;
     resolveServiceDid: (serviceUrl: string) => Promise<string | null>;
+    hasSigningKey: () => boolean;
+    createInvocationFromDelegation: (
+      delegationCar: string,
+      serviceUrl: string,
+      capability: { can: string; with: string },
+      options?: { maxTtlSeconds?: number },
+    ) => Promise<{ invocation: string } | { error: string }>;
   };
   llm: {
     get: (role: ModelRole, params?: ChatOpenAIFields) => BaseChatModel;
@@ -126,6 +138,24 @@ export interface RuntimeContext<TConfig = MergedConfig> {
     Backed by today's `SecretsService`. Returns nothing if the encryption key isn't provisioned.
   </Accordion>
 
+  <Accordion title="blobStore" icon="box-archive">
+    Short-TTL, user-namespaced store for content the LLM must **never relay verbatim** — UCAN invocation CARs, JWTs, signed envelopes. A producing tool stores the value and returns a short opaque ID; a consuming tool looks it up server-side and forwards it on. The model only ever sees the ID.
+
+    - `put({ userDid, name, value, ttlSeconds? })` — store a value, returns a fresh `blob_<16 hex>` ID. TTL defaults to 1h and is clamped to the service max (24h). Pass `userDid` from a **trusted source** (e.g. `rtCtx.user.did`) — never from LLM-supplied tool args.
+    - `get({ userDid, blobId })` — retrieve a blob scoped to the requesting user. Returns `null` if it doesn't exist, has expired, or belongs to a different user (cross-user reads always miss).
+    - `isValidBlobId(value)` — cheap format check (`blob_<16 hex>`); use it in a tool's input handler to reject malformed IDs before paying for a lookup.
+
+    ```ts
+    const blobId = await rtCtx.blobStore.put({
+      userDid: rtCtx.user.did,
+      name: 'signed-invocation',
+      value: signedCar,
+    });
+    // hand `blobId` back to the model; resolve it server-side in the next tool
+    const blob = await rtCtx.blobStore.get({ userDid: rtCtx.user.did, blobId });
+    ```
+  </Accordion>
+
   <Accordion title="matrix" icon="cube">
     Scoped Matrix operations.
 
@@ -143,6 +173,21 @@ export interface RuntimeContext<TConfig = MergedConfig> {
     - `hasCapability(resource, action)` — boolean check.
     - `mintInvocation({ did, capability }, opts?)` — mint a downstream invocation signed by the oracle's signing mnemonic.
     - `resolveServiceDid(serviceUrl)` — look up a downstream service's DID document; returns `id` or `null`.
+    - `hasSigningKey()` — `true` once the oracle has loaded its Ed25519 signing mnemonic. **Gate registration of mint-capable tools on this**: without a key, minting is a no-op, so the tool should surface an error rather than pretend it worked.
+    - `createInvocationFromDelegation(delegationCar, serviceUrl, capability, options?)` — mint an invocation from a **directly-supplied** delegation CAR (rather than the user's cached one), targeted at a specific service route. Returns `{ invocation }` on success or `{ error }` with a surfaced-verbatim reason (missing signing key, audience mismatch, did:web unreachable, …).
+
+    ```ts
+    if (!rtCtx.ucan.hasSigningKey()) {
+      return { error: 'This oracle is not configured to mint invocations.' };
+    }
+    const result = await rtCtx.ucan.createInvocationFromDelegation(
+      delegationCar,
+      'https://service.example',
+      { can: 'submit', with: 'service:claims' },
+    );
+    if ('error' in result) return { error: result.error };
+    // use result.invocation
+    ```
   </Accordion>
 
   <Accordion title="llm" icon="brain">

--- a/build-an-oracle/reference/state-schema.mdx
+++ b/build-an-oracle/reference/state-schema.mdx
@@ -18,10 +18,9 @@ export const MainAgentGraphState = Annotation.Root({
   editorRoomId: Annotation<string | undefined>({ /* ... */ }),
   spaceId: Annotation<string | undefined>({ /* ... */ }),
   currentEntityDid: Annotation<string | undefined>({ /* ... */ }),
-  browserTools: Annotation<BrowserToolCallDto[] | undefined>({ /* ... */ }),
-  agActions: Annotation<AgActionDto[] | undefined>({ /* ... */ }),
+  browserTools: Annotation<BrowserToolCall[] | undefined>({ /* default: () => [] */ }),
+  agActions: Annotation<AgAction[] | undefined>({ /* default: () => [] */ }),
   userContext: Annotation<UserContextData>({ /* ... */ }),
-  mcpUcanContext: Annotation<{ invocations: Record<string, string> } | undefined>({ /* ... */ }),
   userPreferences: Annotation<UserPreferences | undefined>({ /* ... */ }),
   loadedPlugins: Annotation<string[]>({
     reducer: (current, update) =>
@@ -80,17 +79,19 @@ Plugins read state via `rtCtx.history.state` (typed as `ReadonlyState`) or via s
   </Accordion>
 
   <Accordion title="browserTools" icon="browser">
-    - **Type:** `BrowserToolCallDto[] | undefined`
+    - **Type:** `BrowserToolCall[] | undefined`
+    - **Default:** `[]` (empty array).
     - **Owner:** Portal client.
 
-    Browser tools declared by the Portal frontend for this turn. The Portal plugin's sub-agent only builds when this array is non-empty.
+    Browser tools declared by the Portal frontend for this turn. Each entry is `{ name, description, schema }`. The Portal plugin's sub-agent only builds when this array is non-empty.
   </Accordion>
 
   <Accordion title="agActions" icon="table-cells">
-    - **Type:** `AgActionDto[] | undefined`
+    - **Type:** `AgAction[] | undefined`
+    - **Default:** `[]` (empty array).
     - **Owner:** Portal client (AG-UI).
 
-    AG-UI actions declared by the frontend. The AG-UI plugin's sub-agent only builds when this is non-empty.
+    AG-UI actions declared by the frontend. Each entry is `{ name, description, schema, hasRender? }`. The AG-UI plugin's sub-agent only builds when this is non-empty.
   </Accordion>
 
   <Accordion title="userContext" icon="user">
@@ -98,13 +99,6 @@ Plugins read state via `rtCtx.history.state` (typed as `ReadonlyState`) or via s
     - **Owner:** Memory plugin (writes via enrichment middleware).
 
     Memory-enriched user profile. Other plugins read via `rtCtx.shared.userProfile` (registered by Memory's `getSharedState`).
-  </Accordion>
-
-  <Accordion title="mcpUcanContext" icon="shield">
-    - **Type:** `{ invocations: Record<string, string> } | undefined`
-    - **Owner:** runtime / UCAN service.
-
-    Pre-minted MCP UCAN invocations indexed by service name.
   </Accordion>
 
   <Accordion title="userPreferences" icon="sliders">
@@ -149,7 +143,9 @@ Each field has a reducer that merges partial updates from agent nodes:
 - **`loadedPlugins`** — union via Set; never removes.
 - Most other fields use last-write-wins or "merge if present" semantics; consult the source for the exact reducer when authoring middleware that mutate state.
 
-Plugin middleware that need to update state should return a partial state object from the hook. The runtime applies it through the reducer pipeline.
+<Warning>
+Plugin middleware hooks must **not** return a partial state object (`{ messages: ... }`, etc.). A middleware hook returns only `undefined` (pass through) or `{ jumpTo: 'end' as const }` (flow control). Returning a state channel from `beforeAgent` / `wrapModelCall` / `afterModel` breaks LangGraph checkpointer thread continuity (the symptom is "a new thread per message"). Message rewrites belong in the transport/messages layer, not in a middleware.
+</Warning>
 
 ## Checkpointing
 

--- a/build-an-oracle/troubleshooting.mdx
+++ b/build-an-oracle/troubleshooting.mdx
@@ -118,7 +118,7 @@ Important: the runtime starts HTTP listening even when Matrix is still pending. 
 
 **Cause:** The oracle's Matrix account room doesn't contain the encrypted signing mnemonic state event.
 
-**Fix:** Run the CLI command to provision it. Until then, authenticated routes will 401.
+**Fix:** Run `qiforge-cli setup-encryption-key` to provision it. Until then, authenticated routes will 401. (The boot warning still prints the legacy command name `oracles-cli setup-claim-signing-mnemonics`; the current CLI provisions the signing key under `qiforge-cli setup-encryption-key`.)
 
 ### Boot warns: No P-256 encryption key found
 
@@ -184,12 +184,20 @@ The plugin loaded but its `softDependsOn` is missing. This is informational — 
 
 ### Every protected request returns 401
 
-Likely causes:
+When no auth is present at all, the middleware returns **401** with:
 
+```text
+Missing UCAN authentication: provide Authorization: Bearer <invocation> with X-Auth-Type: ucan, or an x-ucan-delegation header
+```
+
+A malformed or expired invocation returns **401** `Invalid UCAN invocation`. Likely causes:
+
+- **No invocation sent.** Primary auth is a user-signed UCAN invocation carried as `Authorization: Bearer <invocation>` **plus** `X-Auth-Type: ucan` — the bearer is ignored without the `X-Auth-Type: ucan` selector. (A bare `x-ucan-delegation` header is accepted only as a migration fallback.)
+- **Invocation expired or malformed**, or its lifetime exceeds `UCAN_AUTH_MAX_TTL_SECONDS` (default 900s).
 - **Matrix init still pending.** The runtime needs Matrix up to validate UCANs. Watch for `[plugin] matrix pending → loaded` before retrying.
-- **Signing mnemonic not loaded** (see Matrix issues above). Auth middleware can't mint downstream invocations.
-- **UCAN delegation expired or malformed.** Check the `x-ucan-delegation` header.
-- **`x-did` doesn't match the delegation.** The middleware verifies the audience.
+- **Signing mnemonic not loaded** (see Matrix issues above). The oracle can't mint downstream invocations until it's provisioned.
+
+`x-did` is **not** used for authentication — the authenticated DID is derived from the validated invocation (or delegation), never from a header the client sets. See [Identity and auth](/build-an-oracle/develop/identity-and-auth#per-request-user-auth).
 
 ### My webhook hits 401
 
@@ -218,7 +226,6 @@ If you wrote a middleware with closure-scoped timing state, concurrent LLM calls
 
 - Check `app.plugins.status()` — `loaded`, `excluded` (with reason), `softDepGaps`.
 - Check the Swagger UI at `/docs` — the live route list.
-- Run `qiforge inspect` (once TASK-33 ships) for a structured registry dump.
 - Open the LangSmith trace for the failing turn.
 
 ## Where to read next

--- a/build-an-oracle/understand/architecture.mdx
+++ b/build-an-oracle/understand/architecture.mdx
@@ -45,7 +45,7 @@ Typically `apps/your-oracle/src/main.ts` (a `createOracleApp(...)` call), a `con
 
 ### Layer 2 — `@ixo/oracle-runtime`
 
-The framework. Owns the bootstrap (`createOracleApp`), the always-on Nest modules (Sessions, Messages, WebSocket, Secrets, UCAN, Auth, Subscription, Throttler, Health), the per-request agent builder, the four always-on middleware, the Matrix-backed SQLite checkpointer, and the plugin API.
+The framework. Owns the bootstrap (`createOracleApp`), the always-on Nest modules (Sessions, Messages, WebSocket, Secrets, UCAN, Auth, Subscription, Throttler, Health), the per-request agent builder, the four always-on agent middleware (capability gate, tool validation, tool-repetition guard, tool retry — plus page-context and safety-guardrail when their hooks are set), the Matrix-backed SQLite checkpointer, and the plugin API.
 
 You never edit this layer. Updates come via `pnpm update @ixo/oracle-runtime`.
 
@@ -99,6 +99,38 @@ Source: [`packages/oracle-runtime/src/registries/`](https://github.com/ixoworld/
 | Anything inside a custom plugin | The six registries |
 
 If you find yourself wanting to swap something on the "Fixed" side, you're probably trying to do something the framework explicitly doesn't allow — and you should either work within the model (e.g. write a plugin) or fork the runtime.
+
+## Model resolution and hooks
+
+How does the agent pick which LLM to call, and how do you change it?
+
+**Provider is env-driven.** `LLM_PROVIDER` selects the whole per-role model map: `openrouter` (default) or `nebius`, each with its matching API key (`OPEN_ROUTER_API_KEY` / `NEBIUS_API_KEY`). The actual model id for each role (`main`, `subagent`, `utility`, `vision`, `guard`, …) is baked into the provider's model map — there is no env var to change a single role's model id on its own.
+
+**Resolution is per-role.** Different jobs use different models. The main agent resolves the `main` role; sub-agents and utility calls resolve `subagent` / `utility` through `ctx.llm.get(role)`. The runtime resolves the main model as `resolveModel('main')`, defaulting to the provider map.
+
+**To change the main agent's model, pass `hooks.resolveModel`** to `createOracleApp`. Spreading `params` keeps the provider's fallback models and latency sorting:
+
+```ts
+import { createOracleApp, getProviderChatModel } from '@ixo/oracle-runtime';
+
+const app = await createOracleApp({
+  config,
+  plugins,
+  hooks: {
+    // role is 'main' | 'subagent' | 'utility'. Spreading params preserves
+    // the provider's fallback models + latency sort.
+    resolveModel: (role, params) =>
+      getProviderChatModel(role, {
+        ...params,
+        ...(role === 'main' && { model: 'google/gemini-3.1-flash-lite' }),
+      }),
+  },
+});
+```
+
+The runtime only calls `resolveModel('main')` itself, so a hook that special-cases `'main'` swaps **only the main agent's model**; sub-agents and utility calls keep the provider defaults unless your own code routes them through the hook too.
+
+`resolveModel` is one of several `hooks` — the framework's advanced extension surface. Others include `checkpointerForUser` (swap the per-user checkpointer), `safetyModel` (enable the safety-guardrail middleware), `getRoomTitle` (enable the page-context middleware), and prompt-block overrides like `operationalMode`. See the [`createOracleApp` reference](/build-an-oracle/reference/createoracleapp) for the full list.
 
 ## Read next
 

--- a/build-an-oracle/understand/contexts.mdx
+++ b/build-an-oracle/understand/contexts.mdx
@@ -40,12 +40,14 @@ Everything in `PluginContext`, plus:
 | `session` | Thread ID (= `session.id`), client (`portal` / `matrix` / `slack`), request ID, room ID |
 | `history` | `messages`, `recent(n)`, `userContext`, typed `state` view |
 | `secrets` | `getIndex()`, `getValues(keys)` for per-user secrets |
+| `blobStore` | Short-TTL keyed store for values the model must never echo verbatim (UCAN invocation CARs, JWTs): `put()` returns an opaque `blob_<hex>` id, `get()` resolves it server-side, `isValidBlobId()` checks the format. Blobs are scoped to the issuing user's DID |
 | `matrix` | Scoped methods: `postToRoom`, `getRoomState`, `getEventById` |
-| `ucan` | `requireCapability`, `hasCapability`, `mintInvocation`, `resolveServiceDid` |
-| `llm` | `get(role, params)` for the configured provider |
+| `ucan` | `requireCapability`, `hasCapability`, `mintInvocation`, `resolveServiceDid`, `hasSigningKey()`, `createInvocationFromDelegation()` |
+| `llm` | `get(role, params)` for the configured provider — `role` is `'main'` / `'subagent'` / `'utility'` |
 | `emit` | Typed event emitter (`toolCall`, `actionCall`, `renderComponent`, `reasoning`, ...) |
 | `shared` | Typed reads from other plugins' `getSharedState` |
 | `loadedPlugins` | Set of plugin names loaded for this thread |
+| `toolCallId` | The current tool call's id — needed when a tool returns a LangGraph `Command` |
 | `abortSignal` | Request-scoped abort |
 
 Full field list and types: [RuntimeContext reference](/build-an-oracle/reference/runtime-context).

--- a/build-an-oracle/understand/manifest.mdx
+++ b/build-an-oracle/understand/manifest.mdx
@@ -17,10 +17,10 @@ Every plugin declares a `manifest` of type `PluginManifest`. It is not human doc
 | Field | Purpose |
 | --- | --- |
 | `title` | Human-readable label. Distinct from `name` (kebab-case unique ID). |
-| `summary` | One-line description. Rendered in Tier-1 for `always` plugins as `- {name}: {summary}`. |
-| `whenToUse` | Trigger phrases. The single most important field — quality here determines whether the LLM picks the plugin when it should. Required when `visibility !== 'silent'`. |
-| `whenNotToUse` | Anti-pattern phrases. Use to disambiguate from overlapping plugins. |
-| `examples` | Few-shot user-message → tool-call bindings. Cross-checked at boot — every example's `tool` must reference a tool this plugin registers. |
+| `summary` | One-line description. Heads each Tier-1 entry for `always` plugins as `- **{name}** — {summary}`. |
+| `whenToUse` | Trigger phrases. The single most important field — quality here determines whether the LLM picks the plugin when it should. Required when `visibility !== 'silent'`. The first two render into Tier-1 as a `When to use:` sub-bullet. |
+| `whenNotToUse` | Anti-pattern phrases. Use to disambiguate from overlapping plugins. The first renders into Tier-1 as an `Avoid for:` sub-bullet. |
+| `examples` | Few-shot user-message → tool-call bindings. Cross-checked at boot — every example's `tool` must reference a tool this plugin registers. The first renders into Tier-1 as an `Example:` sub-bullet. |
 | `tags` | Lowercase labels for search. |
 | `category` | One of: `data`, `communication`, `automation`, `memory`, `integration`, `ui`, `auth`, `observability`, `core`. |
 | `visibility` | `always` / `on-demand` / `silent`. See [Visibility tiers](/build-an-oracle/understand/visibility-tiers). |
@@ -34,13 +34,13 @@ Full schema table and validation rules live at [Manifest schema reference](/buil
 graph LR
     Manifest["manifest"] --> Tier1["Tier-1 prompt block<br/>(if visibility=always)"]
     Manifest --> ListCaps["list_capabilities()"]
-    Manifest --> LoadCap["load_capability(name)"]
+    Manifest --> LoadCap["load_capability({ names })"]
     Tier1 --> System["System prompt<br/>every turn"]
     ListCaps --> Agent["Agent"]
     LoadCap --> Agent
 ```
 
-Tier-1 plugins pay token cost on every turn forever. `on-demand` plugins cost nothing until the agent loads them. `silent` plugins are never visible to the LLM.
+Tier-1 plugins pay token cost on every turn forever — and not just the summary: each entry also renders `whenToUse`, `whenNotToUse`, and the first `example` as sub-bullets, so manifest length is prompt length. `on-demand` plugins cost nothing in the prompt until the agent loads them. `silent` plugins are never listed in Tier-1 and can't be loaded through the meta-tools (note: a silent plugin's tools, if it ships any, are still bound and callable — `silent` is not a security boundary).
 
 ## Writing a good manifest
 

--- a/build-an-oracle/understand/meta-tools-and-loading.mdx
+++ b/build-an-oracle/understand/meta-tools-and-loading.mdx
@@ -6,18 +6,20 @@ icon: "magnifying-glass"
 
 ## Why meta-tools exist
 
-A QiForge oracle can have dozens of plugins installed. Binding every one of them to the agent at boot would explode the prompt and the tool list. Instead, `on-demand` plugins are invisible at boot — the agent discovers them mid-conversation via two built-in meta-tools and loads what it needs for the current thread.
+A QiForge oracle can have dozens of plugins installed. Listing every one in the prompt would explode the system prompt and the tool list the model has to reason over. Instead, `on-demand` plugins are **not advertised** at boot — the agent discovers them mid-conversation via two built-in meta-tools and loads what it needs for the current thread.
 
-The runtime registers these tools itself. They are not authored by any plugin and cannot be overridden.
+Under the hood every tool is bound to the agent at compile time; a `CapabilityGateMiddleware` hides on-demand tools from the model until their plugin is loaded (see [How on-demand gating works](/build-an-oracle/understand/visibility-tiers#how-on-demand-gating-actually-works)). So "loading" lifts a per-turn filter — it does not bind new tools.
+
+The runtime registers these meta-tools itself. They are not authored by any plugin and cannot be overridden.
 
 ## The two tools
 
 | Tool | Purpose |
 | --- | --- |
 | `list_capabilities` | Returns every visible plugin with its summary, visibility, loaded status, category, and tags. The agent uses this to scan what's available. |
-| `load_capability` | Marks a plugin as loaded for the current thread, returns its full manifest plus tool descriptions, and appends a `ToolMessage` so the agent sees the manifest in conversation history on the same turn. |
+| `load_capability` | Takes `names: string[]` — an array, so the agent can load several capabilities in one call. Marks each plugin as loaded for the current thread, returns each one's full manifest plus tool descriptions, and appends a `ToolMessage` so the agent sees the manifests in conversation history on the same turn. |
 
-`load_capability` errors when the named plugin doesn't exist, when it is `silent` (silent plugins are internal, not agent-loadable), and a no-op (returns `alreadyAvailable: true`) when the plugin is `always` or has already been loaded for this thread.
+`load_capability` accepts a batch and is processed per name: it throws when a named plugin doesn't exist, throws when one is `silent` (silent plugins are internal, not agent-loadable), and treats a name that is `always` or already loaded as a no-op (`alreadyAvailable: true`). Batching is preferred — the prompt instructs the agent to pass every capability it needs in a single `load_capability({ names: [...] })` call rather than making multiple calls in the same turn.
 
 ## The discovery loop
 
@@ -34,10 +36,10 @@ sequenceDiagram
     Note over Agent: No weather tool bound — plugin is on-demand
     Agent->>ListCaps: list_capabilities()
     ListCaps-->>Agent: [..., { name: 'weather', loaded: false }, ...]
-    Agent->>LoadCap: load_capability({ name: 'weather' })
+    Agent->>LoadCap: load_capability({ names: ['weather'] })
     LoadCap->>State: loadedPlugins += ['weather']
-    LoadCap-->>Agent: manifest + tools
-    Note over Agent: Next turn includes get_current_weather
+    LoadCap-->>Agent: manifests + tools
+    Note over Agent: Capability gate now passes get_current_weather
     Agent->>User: (calls get_current_weather, returns answer)
 ```
 
@@ -51,28 +53,30 @@ Loading a plugin in thread A does not affect thread B. Every new conversation re
 
 ## What the agent sees in the system prompt
 
-For `always` plugins, the runtime renders a Tier-1 prompt block:
+For `always` plugins, the runtime renders a Tier-1 prompt block. Each entry is more than a one-liner — the plugin name and summary, then sub-bullets pulled straight from the manifest (`whenToUse`, `whenNotToUse`, and the first `example`):
 
 ```text
 ## Available Capabilities
 
-- memory: Durable memory across conversations...
-- skills: Discover IXO skill capsules...
-- domain-indexer: Domain analysis and entity lookup...
-- sandbox: Per-user Linux box for code execution...
-- user-preferences: ...
+- **memory** — Durable memory across conversations.
+  - When to use: user refers to something from a past chat; you learn a durable fact
+  - Avoid for: one-off lookups that don't need to persist
+  - Example: "remember I prefer metric units" → save_memory({"text":"prefers metric"})
+- **skills** — Discover and run IXO skill capsules.
+  - When to use: a packaged skill could generate a file, report, or run a workflow
+  - Example: "make me an invoice" → search_skills({"query":"invoice"})
 
-For more capabilities, call list_capabilities to discover what else
-you can use, then load_capability to make tools available.
+For more capabilities, call `list_capabilities()` to see what else is available,
+then `load_capability({ names: ["cap1", "cap2"] })` to make their tools available in one call.
 ```
 
-`on-demand` plugins are *not* listed here — the agent has to ask. `silent` plugins are never visible.
+Because `whenToUse`, `whenNotToUse`, and the first example all render into Tier-1, manifest quality directly drives prompt size. `on-demand` plugins are *not* listed here — the agent has to discover them. `silent` plugins are never listed and can't be loaded through the meta-tools.
 
 ## Token cost
 
 | Item | Cost per turn |
 | --- | --- |
-| Tier-1 prompt block | ~80 tokens per `always` plugin |
+| Tier-1 prompt block | ~80–150 tokens per `always` plugin (name + summary + whenToUse/avoid/example sub-bullets) |
 | Bound tool schemas | ~100–300 tokens per tool |
 | Meta-tools themselves | ~100 tokens combined (negligible) |
 

--- a/build-an-oracle/understand/plugin-anatomy.mdx
+++ b/build-an-oracle/understand/plugin-anatomy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Anatomy of a plugin"
-description: "The nine hooks an OraclePlugin can declare and where each one plugs into the runtime."
+description: "The ten contribution channels an OraclePlugin can declare and where each one plugs into the runtime."
 icon: "microscope"
 ---
 
@@ -44,9 +44,11 @@ graph LR
 
 The runtime never reaches inside your plugin. Every contribution flows through one of these channels.
 
-## The nine hooks at a glance
+## The ten contribution channels at a glance
 
-| Hook | What it contributes | When called |
+The first four are **declarative properties** (data the runtime reads); the rest are **hooks** (methods the runtime calls).
+
+| Channel | What it contributes | When called |
 | --- | --- | --- |
 | `manifest` | The agent-facing interface — title, summary, `whenToUse`, examples, visibility | Boot (validation + Tier-1 composition) |
 | `configSchema` | A Zod object merged into the global env schema | Boot (env validation) |
@@ -54,10 +56,12 @@ The runtime never reaches inside your plugin. Every contribution flows through o
 | `autoDetect(env)` | Decide whether to load based on env | Boot (resolution) |
 | `getTools(ctx)` / `getRequestTools(rtCtx)` | LLM-callable tools | Boot cache + per-request |
 | `getSubAgents(ctx)` / `getRequestSubAgents(rtCtx)` | Focused inner agents (auto-wrapped as tools) | Boot cache + per-request |
-| `getMiddlewares(ctx)` | `beforeModel` / `afterModel` / `onError` hooks | Boot cache |
+| `getMiddlewares(ctx)` | LangChain `AgentMiddleware` objects (`beforeAgent` / `beforeModel` / `wrapModelCall` / `afterModel` / `wrapToolCall` / `afterAgent` hooks) | Boot cache |
 | `getNestModules(ctx?)` | Nest modules (HTTP routes, services) | Boot, once |
 | `getAuthExcludedRoutes()` | Routes that skip UCAN auth | Boot, once |
 | `getSharedState()` | Read-only accessors other plugins can consume | Boot, once |
+
+A middleware can declare any of the six LangChain hooks above. There is **no `onError` middleware hook** — to handle an LLM or tool error inside a middleware, wrap the call in `wrapModelCall` / `wrapToolCall` with `try`/`catch`.
 
 Boot-time hooks (`getTools`, `getSubAgents`, `getMiddlewares`) are called once and the results are cached for every request. The per-request variants run on every agent build — use them only when the contribution depends on live state (e.g. `loadedPlugins`, current user, `rtCtx.shared.*`).
 

--- a/build-an-oracle/understand/prompt-anatomy.mdx
+++ b/build-an-oracle/understand/prompt-anatomy.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Prompt anatomy"
-description: "How the runtime assembles the system prompt — 15 sections, what's automatic, what you configure."
+description: "How the runtime assembles the system prompt — 16 sections, what's automatic, what you configure."
 icon: "layer-group"
 ---
 
 ## Overview
 
-Every time the main agent is invoked, the runtime compiles a system prompt from up to 15 sections. Most sections are automatic — the runtime builds them from env state, loaded plugins, and live session data. You are only responsible for three fields in `config.prompt`. Everything else is handled for you.
+Every time the main agent is invoked, the runtime compiles a system prompt from up to 16 sections. Most sections are automatic — the runtime builds them from env state, loaded plugins, and live session data. You are only responsible for four fields in `config.prompt`. Everything else is handled for you.
 
-## The 15 sections
+## The 16 sections
 
 Sections appear in this fixed order. "Always present" means the section is included on every turn regardless of configuration; "conditional" means the section only appears when a specific condition is met.
 
@@ -17,18 +17,19 @@ Sections appear in this fixed order. "Always present" means the section is inclu
 | 1 | **Oracle section** — identity preamble | Always |
 | 2 | **Capabilities note** — `config.prompt.capabilities` text | Conditional |
 | 3 | **Capability block** — Tier-1 plugin manifest list | Conditional |
-| 4 | **Operating principles** — 7 standard bullets + optional style | Always |
-| 5 | **Working with files** — file-handling guidance | Always |
-| 6 | **What you know about the user** — memory context (6 slots) | Conditional |
-| 7 | **Current time** — `{currentTime}` (`{timezone}`) | Always |
-| 8 | **Current entity** — `{DID}` | Conditional |
-| 9 | **Available user secrets** | Conditional |
-| 10 | **User preferences** | Conditional |
-| 11 | **Operational mode** — general / editor / task / entity | Always |
-| 12 | **Composio context** — Composio tool context | Conditional |
-| 13 | **Editor section** — editor plugin state | Conditional |
-| 14 | **Slack formatting constraints** — Slack output rules | Conditional |
-| 15 | **Degraded services** — failed-init notices | Conditional |
+| 4 | **Operating principles** — fixed bullets + optional communication style | Always |
+| 5 | **Custom instructions** — `config.prompt.customInstructions` + loaded operating guides | Conditional |
+| 6 | **Working with files** — file-handling guidance | Always |
+| 7 | **What you know about the user** — memory context (6 slots) | Conditional |
+| 8 | **Current time** — `{currentTime}` (`{timezone}`) | Always |
+| 9 | **Current entity** — `{DID}` | Conditional |
+| 10 | **Available user secrets** | Conditional |
+| 11 | **User preferences** | Conditional |
+| 12 | **Operational mode** — general (default) or editor variants | Always |
+| 13 | **Composio context** — Composio tool context | Conditional |
+| 14 | **Editor section** — editor plugin state | Conditional |
+| 15 | **Slack formatting constraints** — Slack output rules | Conditional |
+| 16 | **Degraded services** — failed-init notices | Conditional |
 
 ### Section details
 
@@ -42,69 +43,74 @@ Rendered if `config.prompt.capabilities` is non-empty. Appears immediately above
 
 **3. Capability block**
 
-Auto-generated list of all loaded plugins with `visibility='always'` (Tier-1). Each entry includes the plugin name and its manifest description. The runtime enforces a **5,000-token soft budget** on this block — if the combined manifest text would exceed that, lower-priority entries are trimmed. You never write this section; the runtime builds it from the loaded plugin set.
+Auto-generated list of all loaded plugins with `visibility='always'` (Tier-1). Each entry is more than a one-liner: the plugin name and summary, then up to three sub-bullets pulled from the manifest — `When to use:` (first two `whenToUse` triggers), `Avoid for:` (first `whenNotToUse`), and `Example:` (the first `examples` entry). Manifest quality therefore drives prompt size. You never write this section; the runtime builds it from the loaded plugin set. See [the 5,000-token capability-block budget](#the-5000-token-capability-block-budget) below — it is a warn-only soft budget, not an auto-trim.
 
 **4. Operating principles**
 
-Always present. Contains 7 hardcoded bullets covering tool use, safety, honesty, and task handling. If `config.prompt.communicationStyle` is non-empty, it is injected here as an additional paragraph after those bullets. If `communicationStyle` is absent, the section still appears — just without the custom style block.
+Always present. Contains a fixed set of operating-principle bullets (currently nine) covering discovery-first tool use, clarifying questions, reporting results, surfacing failures, delegating with context, and completing-then-stopping. If `config.prompt.communicationStyle` is non-empty, it is injected here as an additional paragraph after those bullets. If `communicationStyle` is absent, the section still appears — just without the custom style block.
 
-**5. Working with files**
+**5. Custom instructions**
+
+Conditional. Rendered as a `## Custom Instructions` section when there is anything to put in it. Its body is your `config.prompt.customInstructions` field plus any operating guides contributed by on-demand capabilities the agent has loaded for this thread (e.g. the Flow Builder guide). When nothing contributes, the whole section is omitted and costs zero tokens.
+
+**6. Working with files**
 
 Always present. Hardcoded guidance on how the agent should handle file uploads, attachments, and generated file output.
 
-**6. What you know about the user**
+**7. What you know about the user**
 
 Conditional on the memory plugin being loaded and at least one context slot being populated. Contains up to 6 slots fetched by `UserContextFetcher` before the agent is compiled: `identity`, `work`, `goals`, `interests`, `relationships`, `recent`. See [How memory reaches the prompt](/build-an-oracle/reference/bundled-plugins/memory) for the pre-fetch details.
 
-**7. Current time**
+**8. Current time**
 
 Always present. Stamped at agent-compile time with the user's wall-clock time and resolved timezone.
 
-**8. Current entity**
+**9. Current entity**
 
 Conditional on `state.currentEntityDid` being set in the agent state. Surfaces the active entity DID so the agent can route entity-aware tool calls correctly.
 
-**9. Available user secrets**
+**10. Available user secrets**
 
 Conditional on the secrets service having entries for the current user. Lists secret names (not values) so the agent can reference them by name in tool calls.
 
-**10. User preferences**
+**11. User preferences**
 
 Conditional on the user-preferences plugin being loaded and the user having saved preferences. May include `agentName`, `language`, `tone`, `formality`, and `customInstructions`.
 
-**11. Operational mode**
+**12. Operational mode**
 
-Always present, but content varies. The runtime selects one of four mode descriptions — `general`, `editor`, `task`, or `entity` — based on which plugins are active and the current session state.
+Always present, but content varies. The runtime ships a `general` default (`DEFAULT_OPERATIONAL_MODE`) and editor-mode variants supplied by the editor plugin. Any other mode arrives through `hooks.operationalMode` — a plugin or host override — not a built-in runtime selection. See [Model resolution & hooks](/build-an-oracle/understand/architecture#model-resolution-and-hooks).
 
-**12. Composio context**
+**13. Composio context**
 
 Conditional on the Composio plugin loading successfully. Auto-injected Composio account and connection context so the agent knows which third-party integrations are available for the current user.
 
-**13. Editor section**
+**14. Editor section**
 
 Conditional on the editor plugin being active in the current session. Describes the active document, cursor position, and editor affordances.
 
-**14. Slack formatting constraints**
+**15. Slack formatting constraints**
 
 Conditional on the session client being Slack. Appends Slack-specific formatting rules to prevent the agent from using markdown that Slack does not render correctly (e.g. tables).
 
-**15. Degraded services**
+**16. Degraded services**
 
 Appended after the main prompt when one or more plugins fail their init. Lists the failed services and tells the agent not to attempt their tools for this turn.
 
 ## The 5,000-token capability block budget
 
-Section 3 (the Tier-1 capability block) is the only section subject to a token budget. If the combined manifest text of all `visibility='always'` plugins exceeds 5,000 tokens, the runtime trims lower-priority plugins from the block. The trimmed plugins are still loaded and their tools are still callable — they simply don't appear in the capability summary at the top of the prompt. To keep a plugin's description in the block reliably, keep its manifest description concise.
+Section 3 (the Tier-1 capability block) is the only section with a token budget — and it is a **warn-only soft budget, not a cap**. If the combined manifest text of all `visibility='always'` plugins exceeds 5,000 tokens, the runtime logs a warning naming the largest manifests so you can decide what to mark `on-demand`. Nothing is trimmed automatically: the full block is always emitted with every `always` plugin in it. Degrading verbosity is an operator decision, not a runtime guess — so keep manifest text (`summary`, `whenToUse`, `examples`) concise to keep the block small.
 
 ## What you actually need to write in config.ts
 
-Only three things — all optional:
+Only four things — all optional:
 
 | Field | What to write | What happens if you skip it |
 | --- | --- | --- |
 | `config.prompt.opening` | A paragraph describing the oracle's identity, purpose, and domain expertise. | Runtime generates a generic fallback from `name`, `org`, `description`. |
 | `config.prompt.communicationStyle` | One or two paragraphs on tone, vocabulary, and response style. | The operating-principles section appears without a custom style block. |
 | `config.prompt.capabilities` | A short section (with your own heading) listing what the oracle can do. | The capability-notes section is omitted; only the auto-generated plugin list appears. |
+| `config.prompt.customInstructions` | Standing guidance that should hold across every turn (house rules, escalation policy, domain constraints). | The `## Custom Instructions` section is omitted unless a loaded capability contributes a guide. |
 
 Time, memory, user preferences, Composio context, entity DID, secrets, editor state, Slack constraints, and degraded-service notices are all injected automatically. You do not need to mention them in `config.ts`, instruct the agent to fetch them, or account for them in your opening paragraph.
 
@@ -133,11 +139,14 @@ When something is uncertain, say so explicitly.`,
 - Retrieve live project status and registry issuance data.
 - Draft verification reports, CORSIA letters, and board summaries.
 - Search and cite methodology documents from the oracle knowledge base.`,
+    customInstructions: `Always cite the registry framework (Verra VCS, Gold Standard, REDD+)
+behind any compliance claim. Never approve a credit issuance on the user's behalf —
+draft it and ask them to confirm.`,
   },
 };
 ```
 
-Everything else in the 15-section prompt — plugin tools, current time, user memory, preferences, Composio context — is assembled by the runtime from the loaded plugins and session state.
+Everything else in the 16-section prompt — plugin tools, current time, user memory, preferences, Composio context — is assembled by the runtime from the loaded plugins and session state.
 
 ## Related
 

--- a/build-an-oracle/understand/request-lifecycle.mdx
+++ b/build-an-oracle/understand/request-lifecycle.mdx
@@ -12,7 +12,7 @@ sequenceDiagram
     participant Client
     participant Auth as AuthHeaderMiddleware
     participant Sub as SubscriptionMW<br/>(if credits loaded)
-    participant Throttle as ThrottlerMW
+    participant Throttle as ThrottlerGuard
     participant Ctrl as MessagesController
     participant Agent as createMainAgent
     participant Ckpt as Checkpointer
@@ -42,11 +42,11 @@ sequenceDiagram
 | --- | --- |
 | **AuthHeaderMiddleware** | Validates the UCAN delegation (signature, expiry, audience, capability). Resolves the user's DID and attaches `RuntimeUserContext`. Failure → 401, agent never runs. |
 | **SubscriptionMiddleware** | Only when the `credits` plugin is loaded. Checks user balance. Empty + `DISABLE_CREDITS !== 'true'` → 402. |
-| **ThrottlerMiddleware** | Per-user rate limit. Breach → 429. |
+| **ThrottlerGuard** | Per-user rate limit, registered as a global Nest guard (`APP_GUARD`), not an HTTP middleware. Nest runs middleware before guards, so it still gates after auth and subscription. Breach → 429. |
 | **MessagesController** | Reads the inbound message, looks up the session (creates on first contact), hands off to the agent builder. Returns SSE. |
 | **createMainAgent** | Builds the per-request `RuntimeContext`, reads cached registries, runs `getRequestTools` / `getRequestSubAgents`, composes the prompt, returns a LangChain agent compiled against the per-user checkpointer. |
 | **Checkpointer** | Loads `{ messages, loadedPlugins, userContext, ... }` for this `thread_id` (= session id) from per-user SQLite (synced to Matrix in the background). |
-| **LLM invocation** | Composed prompt + bound tools + state messages go to the model selected by `LLM_PROVIDER`. Plugin middleware fires (`beforeModel`, `afterModel`, `onError`). |
+| **LLM invocation** | Composed prompt + bound tools + state messages go to the model resolved for the `main` role (provider from `LLM_PROVIDER`, or a `hooks.resolveModel` override). Plugin middleware fires (`beforeModel`, `wrapModelCall`, `afterModel`). |
 | **Tool calls** | The agent loop dispatches plugin tools, sub-agent tools, meta-tools, and browser tools. Each emits a typed event so the client can render "Agent called X". |
 | **Save state + stream** | The final state is checkpointed; the assistant message streams over SSE. WS events for intermediate steps have already shipped. |
 
@@ -56,7 +56,8 @@ sequenceDiagram
 | --- | --- |
 | `getTools`, `getSubAgents`, `getMiddlewares`, `getSharedState` | Read from boot cache during agent build |
 | `getRequestTools`, `getRequestSubAgents` | Per-request agent build |
-| `middlewares[].beforeModel` / `afterModel` / `onError` | Around each LLM invocation |
+| `middlewares[].beforeModel` / `wrapModelCall` / `afterModel` | Around each LLM invocation |
+| `middlewares[].wrapToolCall` | Around each tool call |
 | Tool / sub-agent `handler` | When the LLM calls the tool |
 | `getNestModules` controllers | Any HTTP request to a plugin route |
 
@@ -68,7 +69,7 @@ sequenceDiagram
 | Credit check | 402. Agent never runs. |
 | Rate limit | 429. Agent never runs. |
 | Checkpointer load | Error logged; falls back to empty state. Turn proceeds. |
-| LLM | `onError` middleware fires. Default: propagate to client. |
+| LLM | Propagates to the client by default. A middleware can catch it by wrapping the call in `wrapModelCall` with `try`/`catch`. |
 | Tool handler | One retry on validation error; otherwise the error becomes a `ToolMessage` the agent sees. |
 | Sub-agent init | `Promise.allSettled` — log and skip; rest of turn continues. |
 

--- a/build-an-oracle/understand/shared-state.mdx
+++ b/build-an-oracle/understand/shared-state.mdx
@@ -35,7 +35,7 @@ If only your plugin reads it, keep it private.
 - **Read-only.** Consumers never mutate the value. Producers update their own internal state via tool handlers or middleware; the accessor just exposes a view.
 - **Flat namespace.** Keys live in a single global record. Two plugins registering the same key fail boot — no quiet overrides.
 - **Lazy.** Each accessor is a function `(state, runCtx) => value`. It runs every time a consumer reads. Cheap reads only; cache in the producer if derivation is expensive.
-- **Optional.** A consumer must assume the producer may not be installed. `rtCtx.shared.someKey` can be `undefined`. Pair shared state with `softDependsOn` so the soft dependency is explicit in `qiforge inspect`.
+- **Optional.** A consumer must assume the producer may not be installed. `rtCtx.shared.someKey` can be `undefined`. Pair shared state with `softDependsOn` so the soft dependency is explicit in the `app.plugins.status()` report.
 
 ## Typed reads
 

--- a/build-an-oracle/understand/visibility-tiers.mdx
+++ b/build-an-oracle/understand/visibility-tiers.mdx
@@ -1,39 +1,56 @@
 ---
 title: "Visibility tiers"
-description: "Three modes — always, on-demand, silent — that control whether a plugin's tools are bound to the agent at boot, loaded on demand, or hidden entirely."
+description: "Three modes — always, on-demand, silent — that control whether a plugin is advertised in the prompt, discoverable via the meta-tools, and callable by the LLM."
 icon: "eye"
 ---
 
+## All tools are bound; visibility controls exposure
+
+A common misconception: that `visibility` decides whether a plugin's tools are *bound* to the agent. It doesn't. **Every plugin tool — `always`, `on-demand`, and `silent` — is bound to the agent at compile time.** What `visibility` controls is three separate things: whether the plugin is **advertised** in the Tier-1 prompt block, whether it is **discoverable** via the meta-tools, and whether the LLM can **call** its tools right now (the [CapabilityGate](#how-on-demand-gating-actually-works) enforces this last one per model call).
+
 ## The three tiers
 
-| Visibility | Tools bound at boot? | Listed in Tier-1 prompt? | Discoverable via `list_capabilities` / `load_capability`? |
+| Visibility | Callable by the LLM | Listed in Tier-1 prompt | Discoverable via `list_capabilities` / `load_capability` |
 | --- | --- | --- | --- |
-| `always` | Yes | Yes | Yes |
-| `on-demand` | No — until `load_capability(name)` | No | Yes |
-| `silent` | Yes (but invisible to the LLM as tools) | No | No |
+| `always` | Always | Yes | Yes |
+| `on-demand` | After `load_capability({ names: [...] })` for this thread | No | Yes |
+| `silent` | Always (if it ships tools) | No | No |
 
 **Default: `on-demand`.** A plugin without an explicit `visibility` is treated as `on-demand`.
+
+<Warning>
+`silent` does **not** hide a tool from the model. A silent tool passes the CapabilityGate exactly like an `always` tool — it is bound and the LLM can call it on any turn. `silent` only means "not advertised in Tier-1 and not loadable via the meta-tools." In practice silent plugins contribute middleware or HTTP routes rather than LLM tools. Do not use `silent` as a security boundary — it is not one.
+</Warning>
 
 ## What each tier is for
 
 | Tier | Use for | Token cost per turn |
 | --- | --- | --- |
-| `always` | Plugins the agent needs on nearly every turn (e.g. `memory`, `skills`, `user-preferences`) | ~80 tokens for the Tier-1 entry + tool schemas (~100–300 per tool) on every turn |
-| `on-demand` | Plugins useful in narrow situations (e.g. `portal`, `firecrawl`, `composio`) | Zero until loaded; same as `always` after |
-| `silent` | Plugins that act through middleware or HTTP only (e.g. `credits`, `slack`) | Zero in the prompt; middleware still runs |
+| `always` | Plugins the agent needs on nearly every turn (e.g. `memory`, `skills`, `user-preferences`) | ~80–150 tokens for the Tier-1 entry + tool schemas (~100–300 per tool) on every turn |
+| `on-demand` | Plugins useful in narrow situations (e.g. `portal`, `firecrawl`, `composio`) | No Tier-1 entry; tool schemas only count once the plugin is loaded |
+| `silent` | Plugins that act through middleware or HTTP only (e.g. `credits`, `calls`) | No Tier-1 entry and not discoverable; any tools it ships are still bound |
+
+## How on-demand gating actually works
+
+Because all tools are bound at compile time, "loading" a plugin is **not** about binding — it's about lifting a filter. The `CapabilityGateMiddleware` runs on every model call. It reads the thread's `loadedPlugins` set and trims the tool list the model sees:
+
+- `always` and `silent` tools → always pass the gate (the model can call them).
+- `on-demand` tools → pass only when their plugin is in `loadedPlugins`.
+
+`createAgent({ tools })` freezes the bound list, so a `load_capability` call updating state mid-run would otherwise have no effect until the next request rebuilt the agent. Filtering inside the middleware lets a load decision take effect on the very next LLM call. The gate is one of the [always-on middlewares](/build-an-oracle/understand/architecture).
 
 ## Picking a tier
 
 ```mermaid
 graph TD
-    A["Does the LLM need to<br/>see this plugin as tools?"]
-    A -->|No| Silent["silent"]
+    A["Does the LLM need to<br/>call this plugin's tools?"]
+    A -->|"No — it's middleware/HTTP only"| Silent["silent"]
     A -->|Yes| B["Will the LLM use it<br/>on most turns?"]
     B -->|Yes| Always["always"]
     B -->|No| OnDemand["on-demand"]
 ```
 
-Promoting to `always` is a deliberate budget choice. Demoting to `silent` is a deliberate architectural choice. Most plugins should stay on the default — `on-demand`.
+Promoting to `always` is a deliberate budget choice — it pays Tier-1 tokens on every turn. `silent` is for plugins that don't need to be advertised or discovered (they work through middleware or HTTP). Most plugins should stay on the default — `on-demand`.
 
 <Tip>
 A fork with 50 plugins, all `on-demand`, can typically keep 3–5 loaded per thread. The agent learns to discover via `list_capabilities` and load via `load_capability`. Token cost stays bounded; the catalog can grow.


### PR DESCRIPTION
## For everyone (plain-language summary)

The **Build-an-Oracle** guide is what developers follow to build an AI agent ("Oracle") on QiForge. Over time it had drifted out of sync with the actual software — some pages described things that had changed, named settings that no longer exist, or showed example code that wouldn't run, and the most-asked question ("how do I change the AI model?") wasn't answered anywhere. This PR reviews **every page (all 60)** against the real software, the working example project, and the CLI, then corrects what was wrong, fills in what was missing, and makes sure every example actually runs.

**By the numbers:** 78 issues fixed across 49 of 60 pages.

## What changed

- **Changing the AI model (the original gap):** documented `createOracleApp({ hooks: { resolveModel } })` with a copy-paste example; enumerated **all** `createOracleApp` options, the full `OracleApp` return surface, and all 10 `MainAgentHooks` fields.
- **Auth model:** corrected every page to invocation-primary (`Authorization: Bearer <invocation>` + `X-Auth-Type: ucan`), with `x-ucan-delegation` as downstream-authorization + migration fallback; exact 401 strings; `x-auth-type` added to CORS; documented `/delegation` endpoints + real WebSocket events.
- **Plugin middleware:** removed the fabricated `onError` hook (real hooks: `beforeAgent`/`beforeModel`/`wrapModelCall`/`wrapToolCall`/`afterModel`/`afterAgent`); corrected the always-on stack; fixed dangerous "return a partial state object" guidance.
- **Bundled plugins:** rewrote `tasks.mdx` for the shipped v2.0.0 plugin; fixed editor/composio/sandbox/skills pages; plugin count is **15**.
- **Reference drift:** added missing UCAN env vars, removed a phantom state channel + fake DTO names, fixed the manifest `tags` rule (hard boot error).
- **Client SDK + CLI:** corrected the `@ixo/oracles-client-sdk` API; fixed the CLI to the real `qiforge-cli` binary (scaffold `new`, chat `--chat`, set-URL `update-oracle-api-url`); removed fabricated commands; normalized default `PORT` to 3000.
- **Create-entity note:** documented that `create-entity` registers the oracle URL as `http://localhost:4000` by default while the runtime default `PORT` is `3000` — set `PORT=4000` to match or change it with `qiforge-cli update-oracle-api-url`.

## How it was verified

Every code example checked against runtime source. Cross-page sweeps clean: no stale port `5678`, no `@ixo/common` mis-import, no "14 plugins", `onError` only as the real `OracleApp.onError` method, `qiforge-cli` only as binary/package name. Frontmatter intact; nav (`docs.json`) has no orphans/broken links.

## Tracking

Linear: **IXO-3105**. Per-finding detail (severity, runtime `path:line`, suggested fix) lives in the boilerplate repo at `docs/docs-audit/`.

A few **source-side follow-ups** (runtime code, not docs) are listed in IXO-3105 — e.g. the example app's stale port comment, two inaccurate JSDoc blocks, and a boot warning that still prints the legacy CLI command.
