### PR TITLE
docs(users): add Outcome Graph access prerequisite

### DIFF
--- a/guides/users/outcome-graph.mdx
+++ b/guides/users/outcome-graph.mdx
@@ -12,7 +12,25 @@ Outcome Graph guides you from a theory of change to a testable map of claims, ca
 
 ## Before you start
 
-Prepare:
+### Confirm access
+
+<Warning>
+  Outcome Graph is not currently available as a self-service feature from this documentation site or the public IXO Portal. The source repository does not yet provide a validated public installation flow. To use this guide, you need a Claude Code session that an IXO maintainer has configured with Outcome Graph.
+</Warning>
+
+Before you prepare a theory of change:
+
+1. Install and authenticate [Claude Code](https://code.claude.com/docs/en/quickstart), if it is not already available to you.
+2. Open the Claude Code session configured for Outcome Graph.
+3. Enter `/help` and confirm that an Outcome Graph command is listed.
+
+The expected result is an Outcome Graph entry that you can select or invoke from the session. If it is missing, [contact IXO support](mailto:assistant@ixo.world) and request **Outcome Graph guided-run access**. Include your organization or IXO domain, and whether your theory of change is text, a document, slides, an infographic, or a transcript.
+
+Do not continue to Step 1 until the Outcome Graph command appears in `/help`.
+
+### Prepare your source
+
+You need:
 
 - a theory of change as text, a document, slides, an infographic, a transcript, or mixed media;
 - the decision or outcome claim you want to clarify;
@@ -56,7 +74,7 @@ Outcome Graph uses phase progress instead of guessing completion time. Effort an
 
 ## Step 1 — Start a diagnostic run
 
-Open a supported agent session with Outcome Graph available. Attach or identify your theory of change, then state the decision you want to clarify.
+Open the configured Claude Code session that you verified above. Attach or identify your theory of change, then state the decision you want to clarify.
 
 For example:
 
@@ -67,7 +85,7 @@ and demonstrable causal chain.
 Do not pursue certificate issuance unless I explicitly approve it later.
 ```
 
-If you use the Claude Code plugin, you can start with:
+You can also use the Outcome Graph command shown in `/help`. The current source package documents this command as:
 
 ```text
 /outcome-graph <path-or-description>


### PR DESCRIPTION
## Summary

- follow up on #49 by replacing the undefined “supported agent session” prerequisite
- state the current access boundary: Outcome Graph is not yet a public self-service Docs or Portal feature
- require a maintainer-configured Claude Code session and provide an explicit `/help` verification step
- link first-time users to the official Claude Code quickstart and route missing access to IXO support
- make Step 1 refer back to the session the reader has already verified

## Why this is an access prerequisite, not self-install instructions

The Outcome Graph source documents local plugin invocation but does not provide a validated public installation flow. Current verification with `claude plugin validate` reports the source manifest's `agents` field as invalid. This change therefore documents the usable access gate and support route instead of publishing installation commands that are not currently verified.

## Files changed

- `guides/users/outcome-graph.mdx`

## Routes or navigation updated

- no route or navigation change

## Validation

- `npm run qa:docs`
- targeted ESLint, markdownlint, and cspell
- IXO documentation style lint in prescriptive mode
- `git diff --check`
- local Mintlify preview returned HTTP 200 and rendered the new access section, Claude Code setup link, and support link
- Mintlify broken-link scan reports only the existing 17 findings in five untouched files

## Open questions or blocked items

- a public self-service Outcome Graph installation path remains source-repository work and is not claimed by this guide

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ixoworld/codesmith/docs/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789830271&installation_model_id=432149&pr_number=50&repository=ixoworld%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fixoworld%2Fdocs%2Fpull%2F50&signature=0566314bf5b11b809236cf3cc3abfef939888f0e6c254a642b4702ca8a4b6a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->